### PR TITLE
Fix for 2-digit forecast hours in web graphics

### DIFF
--- a/scripts/exregional_run_ncl.ksh
+++ b/scripts/exregional_run_ncl.ksh
@@ -19,6 +19,9 @@ echo "Using $THREADS thread(s) for procesing."
 # START_TIME
 # FCST_TIME
 
+FCST_TIME_3=$(printf "%03d" $(( 10#$FCST_TIME )))
+FCST_TIME=$(printf "%02d" $(( 10#$FCST_TIME )))
+
 # Load modules
 module purge
 module load intel
@@ -109,7 +112,7 @@ cd ${workdir}
 pwd
 
 # Link to input file
-${LN} -s ${DATAHOME}/${POST_PREFIX}.t${INIT_HOUR}z.bgdawpf${FCST_TIME}.tm${INIT_HOUR}.grib2 rrfsfile.grb
+${LN} -s ${DATAHOME}/${POST_PREFIX}.t${INIT_HOUR}z.bgdawpf${FCST_TIME_3}.tm${INIT_HOUR}.grib2 rrfsfile.grb
 
 ${ECHO} "rrfsfile.grb" > rrfs_file.txt
 

--- a/scripts/exregional_run_ncl_zip.ksh
+++ b/scripts/exregional_run_ncl_zip.ksh
@@ -37,6 +37,8 @@ else
   START_TIME=$( date +"%Y%m%d%H" -d "${START_TIME}" )
 fi
 
+FCST_TIME=$(printf "%02d" $(( 10#$FCST_TIME )))
+
 # Print out times
 ${ECHO} "   START_TIME = ${START_TIME}"
 ${ECHO} "    FCST_TIME = ${FCST_TIME}"


### PR DESCRIPTION
This change was made in real-time on Oct 9 (5 days ago) for delivering web graphics with the expected names.