### PR TITLE
Change COMOUT existing directory handling.

### DIFF
--- a/jobs/JREGIONAL_RUN_POST
+++ b/jobs/JREGIONAL_RUN_POST
@@ -82,6 +82,7 @@ run_dir="${CYCLE_DIR}${SLASH_ENSMEM_SUBDIR}"
 #
 if [ "${RUN_ENVIR}" = "nco" ]; then
   COMOUT="${COMOUT_BASEDIR}/$RUN.$PDY/$cyc${SLASH_ENSMEM_SUBDIR}"
+  check_for_preexist_dir_file "${COMOUT}" "${PREEXISTING_DIR_METHOD}"
   postprd_dir="$COMOUT"
 else
   postprd_dir="${run_dir}/postprd"

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -1123,7 +1123,6 @@ the experiment generation script."
   COMROOT="$PTMP/com"
 
   COMOUT_BASEDIR="$COMROOT/$NET/$envir"
-  check_for_preexist_dir_file "${COMOUT_BASEDIR}" "${PREEXISTING_DIR_METHOD}"
 
   LOGDIR="${COMROOT}/logs/${NET}/${RUN}.@Y@m@d/@H"
 


### PR DESCRIPTION
The default behavior of setup.sh is to move the COMOUT_BASEDIR when an experiment configuration is generated. This behavior does not work appropriately for multiple dev runs running simultaneously. Instead, move an existing cycle level output directory at UPP run time using the same tooling. This will prevent disruption to other cycles and/or experiments running concurrently.