### PR TITLE
Small fixes to graphics

### DIFF
--- a/ush/config.sh.RRFS_AK_dev1
+++ b/ush/config.sh.RRFS_AK_dev1
@@ -40,7 +40,7 @@ ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_ak"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="alaska"
-MODEL="RRFS-AK (RAPX/FV3_GSD_SAR)"
+MODEL="RRFS_AK (dev1)"
 
 #
 # In NCO mode, the following don't need to be explicitly set to "FALSE" 

--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -40,7 +40,7 @@ ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_dev1"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="conus"
-MODEL="RRFS (HRRRX/FV3_GSD_SAR)"
+MODEL="RRFS_dev1"
 
 #
 # In NCO mode, the following don't need to be explicitly set to "FALSE" 

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -457,7 +457,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <metatask mode="serial" name="&RUN_NCL_TN;">
+  <metatask name="&RUN_NCL_TN;">
 
     <var name="fhr"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %03d" % h  }}{% endfor %} </var>
 


### PR DESCRIPTION
- Shorten model names to avoid overlapping text with some graphics domains
- NCL graphics metatasks should not be "serial", since that slows things down and a single failed forecast hour can end graphics processing for the entire run