### PR TITLE
Revert naming convention for GRIB symlinks in output directories

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -245,9 +245,9 @@ wgrib2 -match "APCP|REFC" ${bgrd3d} -grib ${bgsfc}
 # instead of calling sed.
 start_date=$( echo "${cdate}" | sed 's/\([[:digit:]]\{2\}\)$/ \1/' )
 basetime=$( date +%y%j%H%M -d "${start_date}" )
-ln_vrfy -fs ${bgdawp} ${postprd_dir}/BGDAWP_${basetime}f${fhr}00
-ln_vrfy -fs ${bgrd3d} ${postprd_dir}/BGRD3D_${basetime}f${fhr}00
-ln_vrfy -fs ${bgsfc} ${postprd_dir}/BGSFC_${basetime}f${fhr}00
+ln_vrfy -fs ${bgdawp} ${postprd_dir}/BGDAWP_${basetime}${post_fhr}00
+ln_vrfy -fs ${bgrd3d} ${postprd_dir}/BGRD3D_${basetime}${post_fhr}00
+ln_vrfy -fs ${bgsfc} ${postprd_dir}/BGSFC_${basetime}${post_fhr}00
 
 rm_vrfy -rf ${fhr_dir}
 #

--- a/ush/config.sh.RRFS_AK_dev1
+++ b/ush/config.sh.RRFS_AK_dev1
@@ -40,7 +40,7 @@ ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_ak"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="alaska"
-MODEL="RRFS-AK (RAPX/FV3_GSD_SAR)"
+MODEL="RRFS_AK (dev1)"
 
 #
 # In NCO mode, the following don't need to be explicitly set to "FALSE" 

--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -40,7 +40,7 @@ ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_dev1"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="conus"
-MODEL="RRFS (HRRRX/FV3_GSD_SAR)"
+MODEL="RRFS_dev1"
 
 #
 # In NCO mode, the following don't need to be explicitly set to "FALSE" 

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -457,7 +457,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <metatask mode="serial" name="&RUN_NCL_TN;">
+  <metatask name="&RUN_NCL_TN;">
 
     <var name="fhr"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %03d" % h  }}{% endfor %} </var>
 


### PR DESCRIPTION
Revert naming convention for symlinks to GRIB files in output directories back to pre-RRFS era (2-digit forecast hour and no leading "f").  These links are only used internally within GSL for FTP and web transfers, and this change avoids having our Data Services Group develop a lot of complex logic