### PR TITLE
Added reliability for pushing graphics to the web

### DIFF
--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -511,7 +511,8 @@ MODULES_RUN_TASK_FP script.
 
       <dependency>
         <or>
-        <!--  <taskdep state="Dead" task="&RUN_POST_TN;_#fhr#"/> -->
+          <taskdep state="Dead" task="&RUN_POST_TN;_#fhr#"/>
+          <taskdep state="Dead" task="&RUN_NCL_TN;_#fhr#"/>
           <taskdep task="&RUN_NCL_TN;_#fhr#"/>
         </or>
       </dependency>


### PR DESCRIPTION
Allow ncl_zip_fff to proceed if either post or ncl jobs are dead for that hour.  Since these tasks are sequential, if one ncl_zip is not allowed to proceed, none of the subsequent tasks will either.  So this new method would skip over that hour and continue zipping up subsequent graphics