### PR TITLE
Increase attempts for forecast jobs

### DIFF
--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -630,9 +630,9 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 -->
 {%- if do_dacycle %}
-  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast,dacycle" maxtries="1">
+  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast,dacycle" maxtries="2">
 {% else %}
-  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="1">
+  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="2">
 {% endif %}
 
     &RSRV_FCST;


### PR DESCRIPTION
Increase run_fcst tries to 2.  First attempt often results in a crash in the first few minutes, leading to run reliability of 50% or less.  Have not missed a forecast since adding the second attempt