### PR TITLE
Add config for community workflow test on AWS

### DIFF
--- a/scripts/exregional_run_fcst.sh
+++ b/scripts/exregional_run_fcst.sh
@@ -150,6 +150,7 @@ case $MACHINE in
     ;;
 
   "LINUX")
+    OMP_NUM_THREADS=$(( NCORES_PER_NODE / PPN_RUN_FCST ))
     APRUN=$RUN_CMD_FCST
     ;;
 

--- a/ush/config.community.aws.sh
+++ b/ush/config.community.aws.sh
@@ -1,0 +1,56 @@
+MACHINE="LINUX"
+ACCOUNT="an_account"
+WORKFLOW_MANAGER="rocoto"
+SCHED="slurm"
+
+EXPT_BASEDIR="/lustre"
+EXPT_SUBDIR="test_community"
+
+LMOD_PATH="/apps/lmod/lmod/init/sh"
+BUILD_ENV_FN="build_aws_intel.env"
+
+VERBOSE="TRUE"
+
+RUN_ENVIR="community"
+PREEXISTING_DIR_METHOD="rename"
+
+PREDEF_GRID_NAME="RRFS_CONUS_25km"
+QUILTING="TRUE"
+
+CCPP_PHYS_SUITE="FV3_GFS_v15p2"
+FCST_LEN_HRS="48"
+LBC_SPEC_INTVL_HRS="6"
+
+DATE_FIRST_CYCL="20190615"
+DATE_LAST_CYCL="20190615"
+CYCL_HRS=( "00" )
+
+EXTRN_MDL_NAME_ICS="FV3GFS"
+EXTRN_MDL_NAME_LBCS="FV3GFS"
+
+FV3GFS_FILE_FMT_ICS="grib2"
+FV3GFS_FILE_FMT_LBCS="grib2"
+
+WTIME_RUN_FCST="01:00:00"
+
+# The following are specifically for AWS using Parallel Works
+FIXgsm=${FIXgsm:-"/contrib/NCEPDEV/global/glopara/fix/fix_am"}
+TOPO_DIR=${TOPO_DIR:-"/contrib/NCEPDEV/global/glopara/fix/fix_orog"}
+SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/contrib/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
+FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/contrib/NCEPDEV/global/glopara/fix/FV3LAM_pregen"}
+
+#
+# Uncomment the following line in order to use user-staged external model 
+# files with locations and names as specified by EXTRN_MDL_SOURCE_BASEDIR_ICS/
+# LBCS and EXTRN_MDL_FILES_ICS/LBCS.
+#
+USE_USER_STAGED_EXTRN_FILES="TRUE"
+#
+# The following is specifically for AWS via Parallel Works.  It will have to be
+# modified if on another platform, using other dates, other external models, etc.
+#
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lustre/model_data/FV3GFS"
+EXTRN_MDL_FILES_ICS=( "gfs.pgrb2.0p25.f000" )
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lustre/model_data/FV3GFS"
+EXTRN_MDL_FILES_LBCS=( "gfs.pgrb2.0p25.f006" "gfs.pgrb2.0p25.f012" "gfs.pgrb2.0p25.f018" "gfs.pgrb2.0p25.f024" \
+                       "gfs.pgrb2.0p25.f030" "gfs.pgrb2.0p25.f036" "gfs.pgrb2.0p25.f042" "gfs.pgrb2.0p25.f048" )

--- a/ush/config.community.aws.sh
+++ b/ush/config.community.aws.sh
@@ -6,6 +6,24 @@ SCHED="slurm"
 EXPT_BASEDIR="/lustre"
 EXPT_SUBDIR="test_community"
 
+RUN_CMD_UTILS="srun --mpi=pmi2"
+RUN_CMD_FCST="srun --mpi=pmi2"
+RUN_CMD_POST="srun --mpi=pmi2"
+
+NCORES_PER_NODE="36"
+PPN_RUN_FCST="18"
+LAYOUT_X="4"
+LAYOUT_Y="4"
+WRTCMP_write_groups="1"
+WRTCMP_write_tasks_per_group="2"
+
+PARTITION_DEFAULT=
+QUEUE_DEFAULT=
+PARTITION_HPSS=
+QUEUE_HPSS=
+PARTITION_FCST=
+QUEUE_FCST=
+
 LMOD_PATH="/apps/lmod/lmod/init/sh"
 BUILD_ENV_FN="build_aws_intel.env"
 

--- a/ush/config.sh.aws_cloud
+++ b/ush/config.sh.aws_cloud
@@ -1,79 +1,84 @@
-ACCOUNT=zrtrr
+MACHINE="LINUX"
+ACCOUNT="an_account"
+WORKFLOW_MANAGER="rocoto"
+SCHED="slurm"
 
-MACHINE=LINUX
-WORKFLOW_MANAGER=rocoto
-SCHED=slurm
+EXPT_BASEDIR="/lustre"
+EXPT_SUBDIR="test_rrfs"
 
-LMOD_PATH=/apps/lmod/lmod/init/sh
-BUILD_ENV_FN=build_hera_intel.env
+RUN_CMD_UTILS="srun --mpi=pmi2"
+RUN_CMD_FCST="srun --mpi=pmi2"
+RUN_CMD_POST="srun --mpi=pmi2"
 
-RUN_CMD_UTILS="srun"
-RUN_CMD_FCST="srun"
-RUN_CMD_POST="srun"
+NCORES_PER_NODE="36"
+PPN_RUN_FCST="18"
+LAYOUT_X="16"
+LAYOUT_Y="16"
+WRTCMP_write_groups="1"
+WRTCMP_write_tasks_per_group="32"
 
-NCORES_PER_NODE=40
-PARTITION_DEFAULT="hera"
-QUEUE_DEFAULT=batch
-PARTITION_HPSS=service
-QUEUE_HPSS=batch
-PARTITION_FCST=hera
-QUEUE_FCST=batch
+PARTITION_DEFAULT=
+QUEUE_DEFAULT=
+PARTITION_HPSS=
+QUEUE_HPSS=
+PARTITION_FCST=
+QUEUE_FCST=
 
-EXPT_BASEDIR=/scratch2/BMC/wrfruc/cholt
-EXPT_SUBDIR=rrfs_cloud
-
-RUN=RRFS_CONUS
-
-# Copied directly from setup.sh HERA settings
-FIXgsm=${FIXgsm:-"/scratch1/NCEPDEV/global/glopara/fix/fix_am"}
-TOPO_DIR=${TOPO_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_orog"}
-SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/scratch1/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
-FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/scratch2/BMC/det/FV3LAM_pregen"}
-
-
-# Get external model files
-USE_USER_STAGED_EXTRN_FILES=TRUE
-EXTRN_MDL_SOURCE_BASEDIR_ICS="/scratch2/BMC/wrfruc/cholt/data/gfs"
-EXTRN_MDL_FILES_ICS=( "gfs.t00z.pgrb2.0p25.f000")
-EXTRN_MDL_SOURCE_BASEDIR_LBCS="/scratch2/BMC/wrfruc/cholt/data/gfs"
-EXTRN_MDL_FILES_LBCS=( \
-  "gfs.t00z.pgrb2.0p25.f006"
-  "gfs.t00z.pgrb2.0p25.f012"
-)
-FV3GFS_FILE_FMT_ICS=grib2
-FV3GFS_FILE_FMT_LBCS=grib2
+LMOD_PATH="/apps/lmod/lmod/init/sh"
+BUILD_ENV_FN="build_aws_intel.env"
 
 VERBOSE="TRUE"
 
+NET="RRFS_CONUS"
+RUN="RRFS_CONUS"
 RUN_ENVIR="nco"
+envir="para"
 PREEXISTING_DIR_METHOD="rename"
 
-PREDEF_GRID_NAME=RRFS_CONUS_3km
-
+PREDEF_GRID_NAME="RRFS_CONUS_3km"
 QUILTING="TRUE"
+
 CCPP_PHYS_SUITE="FV3_GSD_SAR"
-FCST_LEN_HRS="12"
-LBC_SPEC_INTVL_HRS="6"
+FCST_LEN_HRS="3"
+LBC_SPEC_INTVL_HRS="3"
 
-HALO_BLEND=10
-
-WTIME_RUN_FCST="06:45:00"
-
-DATE_FIRST_CYCL="20210210"
-DATE_LAST_CYCL="20210210"
+DATE_FIRST_CYCL="20210218"
+DATE_LAST_CYCL="20210218"
 CYCL_HRS=( "00" )
-
 
 EXTRN_MDL_NAME_ICS="FV3GFS"
 EXTRN_MDL_NAME_LBCS="FV3GFS"
 
-envir="para"
+FV3GFS_FILE_FMT_ICS="grib2"
+FV3GFS_FILE_FMT_LBCS="grib2"
 
-NET="RRFS_CONUS"
+WTIME_RUN_FCST="06:45:00"
 
-STMP="/lfs4/BMC/nrtrr/NCO_dirs/stmp"
-PTMP="/lfs4/BMC/nrtrr/NCO_dirs/ptmp"
+HALO_BLEND="10"
 
+STMP="/lustre/stmp"
+PTMP="/lustre/ptmp"
 
-STMP="/scratch2/BMC/wrfruc/cholt/NCO_dirs/rrfs_cloud/stmp"
-PTMP="/scratch2/BMC/wrfruc/cholt/NCO_dirs/rrfs_cloud/ptmp"
+# The following are specifically for AWS using Parallel Works
+FIXgsm=${FIXgsm:-"/contrib/NCEPDEV/global/glopara/fix/fix_am"}
+TOPO_DIR=${TOPO_DIR:-"/contrib/NCEPDEV/global/glopara/fix/fix_orog"}
+SFC_CLIMO_INPUT_DIR=${SFC_CLIMO_INPUT_DIR:-"/contrib/NCEPDEV/global/glopara/fix/fix_sfc_climo"}
+FIXLAM_NCO_BASEDIR=${FIXLAM_NCO_BASEDIR:-"/contrib/NCEPDEV/global/glopara/fix/FV3LAM_pregen"}
+
+#
+# Uncomment the following line in order to use user-staged external model
+# files with locations and names as specified by EXTRN_MDL_SOURCE_BASEDIR_ICS/
+# LBCS and EXTRN_MDL_FILES_ICS/LBCS.
+#
+USE_USER_STAGED_EXTRN_FILES="TRUE"
+#
+# The following is specifically for AWS via Parallel Works.  It will have to be
+# modified if on another platform, using other dates, other external models, etc.
+#
+EXTRN_MDL_SOURCE_BASEDIR_ICS="/lustre/model_data/FV3GFS"
+EXTRN_MDL_FILES_ICS=( "gfs.t00z.pgrb2.0p25.f000")
+EXTRN_MDL_SOURCE_BASEDIR_LBCS="/lustre/model_data/FV3GFS"
+EXTRN_MDL_FILES_LBCS=( \
+  "gfs.t00z.pgrb2.0p25.f003"
+)
+

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -203,7 +203,7 @@ settings="\
 # Number of cores used for a task
 #
   'ncores_run_fcst': ${PE_MEMBER01}
-  'native_run_fcst': --cpus-per-task 4 --exclusive
+  'native_run_fcst': --cpus-per-task $(( NCORES_PER_NODE / PPN_RUN_FCST )) --exclusive
 #
 # Number of logical processes per node for each task.  If running without
 # threading, this is equal to the number of MPI processes per node.

--- a/ush/set_predef_grid_params.sh
+++ b/ush/set_predef_grid_params.sh
@@ -104,8 +104,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-40}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="2"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-2}"
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -148,8 +148,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-32}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -192,8 +194,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-32}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -236,8 +240,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-35}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -284,8 +290,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-40}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -308,8 +316,10 @@ case ${PREDEF_GRID_NAME} in
 # The following rotated_latlon coordinate system parameters were obtained
 # using the NCL code and work.
 #    if [ "$QUILTING" = "TRUE" ]; then
-#      WRTCMP_write_groups="1"
-#      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+#      WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+#      if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+#        WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+#      fi
 #      WRTCMP_output_grid="rotated_latlon"
 #      WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
 #      WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -362,8 +372,8 @@ case ${PREDEF_GRID_NAME} in
 #    BLOCKSIZE="${BLOCKSIZE:-15}"
 #
 #    if [ "$QUILTING" = "TRUE" ]; then
-#      WRTCMP_write_groups="1"
-#      WRTCMP_write_tasks_per_group="2"
+#      WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+#      WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-2}"
 #      WRTCMP_output_grid="lambert_conformal"
 #      WRTCMP_cen_lon="${GFDLgrid_LON_T6_CTR}"
 #      WRTCMP_cen_lat="${GFDLgrid_LAT_T6_CTR}"
@@ -400,8 +410,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-40}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -457,8 +469,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-36}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="rotated_latlon"
     WRTCMP_cen_lon="${GFDLgrid_LON_T6_CTR}"
     WRTCMP_cen_lat="${GFDLgrid_LAT_T6_CTR}"
@@ -512,8 +526,10 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-35}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    if [ -z "$WRTCMP_write_tasks_per_group" ]; then
+      WRTCMP_write_tasks_per_group=$(( 1*LAYOUT_Y ))
+    fi
     WRTCMP_output_grid="rotated_latlon"
     WRTCMP_cen_lon="${GFDLgrid_LON_T6_CTR}"
     WRTCMP_cen_lat="${GFDLgrid_LAT_T6_CTR}"
@@ -647,9 +663,9 @@ case ${PREDEF_GRID_NAME} in
 #This section is all for the write component, which you need for output during model integration
   if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
-    WRTCMP_write_groups="1"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-    WRTCMP_write_tasks_per_group="24"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-24}"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
     WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
@@ -721,9 +737,9 @@ case ${PREDEF_GRID_NAME} in
 #This section is all for the write component, which you need for output during model integration
   if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
-    WRTCMP_write_groups="1"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-    WRTCMP_write_tasks_per_group="8"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-8}"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
     WRTCMP_output_grid="lambert_conformal"
 #These should usually be set the same as compute grid
@@ -797,9 +813,9 @@ case ${PREDEF_GRID_NAME} in
 #This section is all for the write component, which you need for output during model integration
   if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
-    WRTCMP_write_groups="1"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-    WRTCMP_write_tasks_per_group="24"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-24}"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
     WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
@@ -871,9 +887,9 @@ case ${PREDEF_GRID_NAME} in
 #This section is all for the write component, which you need for output during model integration
   if [ "$QUILTING" = "TRUE" ]; then
 #Write component reserves MPI tasks for writing output. The number of "groups" is usually 1, but if you have a case where group 1 is not done writing before the next write step, you need group 2, etc.
-    WRTCMP_write_groups="1"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
 #Number of tasks per write group. Ny must be divisible my this number. LAYOUT_Y is usually a good value
-    WRTCMP_write_tasks_per_group="24"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-24}"
 #lambert_conformal or rotated_latlon. lambert_conformal not well tested and probably doesn't work for our purposes
     WRTCMP_output_grid="lambert_conformal"
 #These should always be set the same as compute grid
@@ -920,8 +936,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-6}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="32"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-32}"
     WRTCMP_output_grid="regional_latlon"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="25.0"
@@ -962,8 +978,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-35}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="32"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-32}"
     WRTCMP_output_grid="regional_latlon"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="25.0"
@@ -1004,8 +1020,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-32}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="32"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-32}"
     WRTCMP_output_grid="regional_latlon"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="25.0"
@@ -1046,8 +1062,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-37}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="1"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-1}"
     WRTCMP_output_grid="lambert_conformal"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"
@@ -1099,8 +1115,8 @@ case ${PREDEF_GRID_NAME} in
 #    BLOCKSIZE="26"
 #
 #    if [ "$QUILTING" = "TRUE" ]; then
-#      WRTCMP_write_groups="1"
-#      WRTCMP_write_tasks_per_group="14"
+#      WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+#      WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-14}"
 #      WRTCMP_output_grid="rotated_latlon"
 #      WRTCMP_cen_lon="${GFDLgrid_LON_T6_CTR}"
 #      WRTCMP_cen_lat="${GFDLgrid_LAT_T6_CTR}"
@@ -1134,8 +1150,8 @@ case ${PREDEF_GRID_NAME} in
   BLOCKSIZE="${BLOCKSIZE:-30}"
 
   if [ "$QUILTING" = "TRUE" ]; then
-    WRTCMP_write_groups="1"
-    WRTCMP_write_tasks_per_group="16"
+    WRTCMP_write_groups="${WRTCMP_write_groups:-1}"
+    WRTCMP_write_tasks_per_group="${WRTCMP_write_tasks_per_group:-16}"
     WRTCMP_output_grid="rotated_latlon"
     WRTCMP_cen_lon="${ESGgrid_LON_CTR}"
     WRTCMP_cen_lat="${ESGgrid_LAT_CTR}"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adds the configuration script for generating community workflow on AWS.  The configuration uses fix files in a permanent location (`/contrib/NCEPDEV/global/glopara/fix`) on Parallel Works, but users are required to copy the initial conditions from the S3 bucket as described in the [instructions](https://github.com/ufs-community/ufs-srweather-app/wiki/Getting-Started).

This PR also:

1.  Adds automatic calculation of `OMP_NUM_TRHEADS` to correct value
2. Adds automatic calculation of `--cpus-per-task` to the correct value.
3. Enables users to override default IO quilting settings
4. Updates 3km config for us in AWS cloud RRFS experiments with correct run commands, layout, and quilting.

This PR is dependent on NOAA-GSL/ufs-srweather-app#14 and should be merged at the same time.

## TESTS CONDUCTED: 
Ran end-to-end community workflow on the AWS Parallel Works platform using Rocoto.  Verified all tasks completed successfully.

## CONTRIBUTORS (optional): 
The `config.community.aws.sh` was adapted from work done by @christinaholtNOAA 
