### PR TITLE
Enable use of RRFS-customized UPP control file

### DIFF
--- a/ush/config.sh.RRFS_dev4
+++ b/ush/config.sh.RRFS_dev4
@@ -34,6 +34,8 @@ envir="para"
 
 NET="RRFS_CONUS"
 
+USE_CUSTOM_POST_CONFIG_FILE="TRUE"
+CUSTOM_POST_CONFIG_FP="/mnt/lfs4/BMC/nrtrr/RRFS/dev4-ufs-srweather-app/src/EMC_post/parm/postxconfig-NT-fv3lam_rrfs.txt"
 ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_dev4"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"


### PR DESCRIPTION
Updating config.sh in RRFS-dev4 to enable use of customized UPP control file, thereby discontinuing use of the "community" UPP control file.

## DESCRIPTION OF CHANGES: 
To deploy this change, first ensure that the latest "EMC_post" is also deployed by updating "Externals.cfg" to latest hash of EMC_post (RRFS_dev).  Then, regenerate the workflow.  These two added lines in config.sh will be transcribed into var_defns.sh

## TESTS CONDUCTED: 
This update was tested successfully in an offline case using RRFS-dev4 (CONUS), and using latest the hash of EMC_post (RRFS_dev branch).

## CONTRIBUTORS (optional): 
@JeffBeck-NOAA 