### PR TITLE
Update to config.sh_dev1 to use RRFS-customized UPP control file

### DIFF
--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -43,6 +43,8 @@ envir="para"
 NET="RRFS_CONUS"
 TAG="RRFS_dev1_CONUS"
 
+USE_CUSTOM_POST_CONFIG_FILE="TRUE"
+CUSTOM_POST_CONFIG_FP="/mnt/lfs4/BMC/nrtrr/RRFS/dev1-ufs-srweather-app/src/EMC_post/parm/postxconfig-NT-fv3lam_rrfs.txt"
 ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_dev1"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"


### PR DESCRIPTION
Updating config.sh in RRFS-dev1 to enable use of customized UPP control file, thereby discontinuing use of the "community" UPP control file.

## DESCRIPTION OF CHANGES: 
This update requires an accompanying mod to srweather-app (Externals.cfg) to use the updated hash for EMC_post.

## TESTS CONDUCTED: 
An identical mod has been successfully deployed into RRFS-dev4 CONUS.

## ISSUE (optional): 
If this PR is resolving or referencing one or more issues, in this repository or elewhere, list them here. For example, "Fixes issue mentioned in #123" or "Related to bug in https://github.com/NOAA-EMC/other_repository/pull/63"

## CONTRIBUTORS (optional): 
@christinaholtNOAA @hu5970 @JeffBeck-NOAA 