### PR TITLE
Update to config.sh_dev3 to use RRFS-customized UPP control file.

### DIFF
--- a/ush/config.sh.RRFS_dev3
+++ b/ush/config.sh.RRFS_dev3
@@ -36,6 +36,8 @@ envir="para"
 
 NET="RRFS_CONUS"
 
+USE_CUSTOM_POST_CONFIG_FILE="TRUE"
+CUSTOM_POST_CONFIG_FP="/mnt/lfs4/BMC/nrtrr/RRFS/dev3-ufs-srweather-app/src/EMC_post/parm/postxconfig-NT-fv3lam_rrfs.txt"
 ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_dev3"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"


### PR DESCRIPTION
Updating config.sh in RRFS-dev3 to enable use of customized UPP control file, thereby discontinuing use of the "community" UPP control file.

## DESCRIPTION OF CHANGES: 
This update requires an accompanying mod to srweather-app (Externals.cfg) to use the updated hash for EMC_post.

## TESTS CONDUCTED: 
An identical mod has been successfully deployed into RRFS-dev4 CONUS.

## CONTRIBUTORS (optional): 
@christinaholtNOAA @hu5970 @JeffBeck-NOAA

