### PR TITLE
RRFS_dev4: Fix the NCL Graphics path to the grib file.

### DIFF
--- a/scripts/exregional_run_ncl.ksh
+++ b/scripts/exregional_run_ncl.ksh
@@ -112,8 +112,16 @@ ${MKDIR} -p ${workdir}
 cd ${workdir}
 pwd
 
-# Link to input file
-${LN} -s ${DATAHOME}/${POST_PREFIX}.t${INIT_HOUR}z.bgdawpf${FCST_TIME_3}.tm${INIT_HOUR}.grib2 rrfsfile.grb
+# Check that the input file exists
+input_file=${DATAHOME}/${POST_PREFIX}.t${INIT_HOUR}z.bgdawpf${FCST_TIME_3}.tm00.grib2
+
+if [ -e $input_file ] ; then
+  # Link to input file
+  ${LN} -sf ${input_file} rrfsfile.grb
+else
+  echo "Cannot find input file: ${input_file}!"
+  exit 1
+fi
 
 ${ECHO} "rrfsfile.grb" > rrfs_file.txt
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Fix an issue with the name of the grib files (tm00) expected in NCL graphics script. Also have the script fail early if the file isn't found. No failures existed at run time when this file was not found.

## TESTS CONDUCTED: 
This change is already running in real time for RRFS_dev1.

The deploy should be a simple pull of regional_workflow. Nothing else is required.
