### PR TITLE
Add new updraft helicity graphics to NCL wrapper script

### DIFF
--- a/scripts/exregional_run_ncl.ksh
+++ b/scripts/exregional_run_ncl.ksh
@@ -156,6 +156,9 @@ set -A ncgms  sfc_temp   \
               10m_gust   \
               sfc_hlcy  \
               in25_hlcy \
+              mx03_hlcy \
+              mx03_hlcytot \
+              mx25_hlcytot \
               sfc_lcl   \
               sfc_tcc   \
               sfc_lcc   \


### PR DESCRIPTION
Brian Jamison has already added the necessary NCL scripts to /home/rtrr/RRFS/graphics/scripts
This change just allows the wrapper script to call them
exregional_run_ncl.ksh has already been updated and tested on Jet without issue