### PR TITLE
Bug fix to get REFC back into the bgsfc GRIB-2 files

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -274,7 +274,7 @@ bgrd3d=${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
 bgsfc=${postprd_dir}/${NET}.t${cyc}z.bgsfcf${fhr}.${tmmark}.grib2
 mv_vrfy BGDAWP.GrbF${post_fhr} ${bgdawp}
 mv_vrfy BGRD3D.GrbF${post_fhr} ${bgrd3d}
-wgrib2 -match "APCP|REFC|PRATE" ${bgrd3d} -grib ${bgsfc}
+wgrib2 -match "APCP|parmcat=16 parm=196|PRATE" ${bgrd3d} -grib ${bgsfc}
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??


### PR DESCRIPTION
Wgrib2 does not recognize the REFC field when center is set to 59
Need to identify the specific parameter category and number instead to match properly
Already made the change as a hot fix on Jet