### PR TITLE
Removing RRFS-dev4 CONUS from reservations

### DIFF
--- a/ush/config.sh.RRFS_dev4
+++ b/ush/config.sh.RRFS_dev4
@@ -1,6 +1,6 @@
 MACHINE="jet"
 ACCOUNT="nrtrr"
-RESERVATION="rrfsdet"
+#RESERVATION="rrfsdet"
 EXPT_BASEDIR="/home/rtrr/RRFS"
 EXPT_SUBDIR="RRFS_dev4"
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Removing RRFS-dev4 from the "rrfsdet" reservation on Jet. 

## TESTS CONDUCTED: 
No tests for this PR have been conducted, but it should be straightforward to implement.

## ISSUE (optional): 
This change was requested during the 3 May RFS Development meeting.

