### PR TITLE
rrfs ens: Extract the output fields required by SFE and store them in the "bgsfc" files

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -274,7 +274,10 @@ bgrd3d=${postprd_dir}/${NET}.t${cyc}z.bgrd3df${fhr}.${tmmark}.grib2
 bgsfc=${postprd_dir}/${NET}.t${cyc}z.bgsfcf${fhr}.${tmmark}.grib2
 mv_vrfy BGDAWP.GrbF${post_fhr} ${bgdawp}
 mv_vrfy BGRD3D.GrbF${post_fhr} ${bgrd3d}
-wgrib2 -match "APCP|parmcat=16 parm=196|PRATE" ${bgrd3d} -grib ${bgsfc}
+#wgrib2 -match "APCP|parmcat=16 parm=196|PRATE" ${bgrd3d} -grib ${bgsfc}
+
+# extract the output fields for the testbed
+wgrib2 ${bgdawp} | grep -F -f ${FIXam}/testbed_fields_bgdawp.txt | wgrib2 -i -grib ${bgsfc} ${bgdawp}
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Extract the output fields required by Spring Forecast Experiment from the **"bgdawp"** GRIB-2 files and store them in the **"bgsfc"** GRIB-2 files, in both native and HRRR grids. This change requires the static file that lists the output fields: /mnt/lfs4/BMC/wrfruc/RRFSE/fix/fix_am.20210128/testbed_fields_bgdawp.txt

## TESTS CONDUCTED: 
Tested in my own space and also RRFSE real-time runs.

## ISSUE (optional): 

## CONTRIBUTORS (optional): 


