### PR TITLE
Fix a bug with 1-element array of additional output grids

### DIFF
--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -2487,6 +2487,7 @@ SFCOBS_USELIST="${SFCOBS_USELIST}"
 
 RADARREFL_MINS=( $(printf "\"%s\" " "${RADARREFL_MINS[@]}" ))
 RADARREFL_TIMELEVEL=( $(printf "\"%s\" " "${RADARREFL_TIMELEVEL[@]}" ))
+ADDNL_OUTPUT_GRIDS=( $(printf "\"%s\" " "${ADDNL_OUTPUT_GRIDS[@]}" ))
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
- Needed a line in setup.sh to maintain 1-element array as such (patterned after the treatment of RADARREFL_MINS variable)
