### PR TITLE
Use different interpolation methods for different grid spacings

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -322,12 +322,19 @@ if [ ${#ADDNL_OUTPUT_GRIDS[@]} -gt 0 ]; then
 
       # Interpolate fields to new grid
       eval infile=\$bg${leveltype}
-      wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
-        -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
-        -new_grid_interpolation bilinear \
-        -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
-        -if ":(NCONCD|NCCICE|SPNCR|CLWMR|CICE|RWMR|SNMR|GRLE|PMTF|PMTC|REFC|CSNOW|CICEP|CFRZR|CRAIN|LAND|ICEC|TMP:surface|VEG|CCOND|SFEXC|MSLMA|PRES:tropopause|LAI|HPBL|HGT:planetary boundary layer):" -new_grid_interpolation neighbor -fi \
-        -new_grid ${grid_specs} ${subdir}/${fhr}/tmp_${grid}.grib2 &
+      if [ ${NET} = "RRFS_NA_13km" ]; then
+         wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
+           -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
+           -new_grid_interpolation bilinear \
+           -if ":(WEASD|APCP|NCPCP|ACPCP|SNOD):" -new_grid_interpolation budget -fi \
+           -if ":(NCONCD|NCCICE|SPNCR|CLWMR|CICE|RWMR|SNMR|GRLE|PMTF|PMTC|REFC|CSNOW|CICEP|CFRZR|CRAIN|LAND|ICEC|TMP:surface|VEG|CCOND|SFEXC|MSLMA|PRES:tropopause|LAI|HPBL|HGT:planetary boundary layer):" -new_grid_interpolation neighbor -fi \
+           -new_grid ${grid_specs} ${subdir}/${fhr}/tmp_${grid}.grib2 &
+      else
+         wgrib2 ${infile} -set_bitmap 1 -set_grib_type c3 -new_grid_winds grid \
+           -new_grid_vectors "UGRD:VGRD:USTM:VSTM:VUCSH:VVCSH" \
+           -new_grid_interpolation neighbor \
+           -new_grid ${grid_specs} ${subdir}/${fhr}/tmp_${grid}.grib2 &
+      fi
       wait 
 
       # Merge vector field records

--- a/ush/setup.sh
+++ b/ush/setup.sh
@@ -2487,6 +2487,7 @@ SFCOBS_USELIST="${SFCOBS_USELIST}"
 
 RADARREFL_MINS=( $(printf "\"%s\" " "${RADARREFL_MINS[@]}" ))
 RADARREFL_TIMELEVEL=( $(printf "\"%s\" " "${RADARREFL_TIMELEVEL[@]}" ))
+ADDNL_OUTPUT_GRIDS=( $(printf "\"%s\" " "${ADDNL_OUTPUT_GRIDS[@]}" ))
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
- RAP-HRRR-like method (bilinear/budget) is not appropriate when going from 3-km ESG to 3-km HRRR.  Use neighbor method in this case to avoid changing the CDFs of discontinuous fields with local maxima/minima like QPF and UH
- Preserve the RAP-HRRR-like methods only for interpolation of 13-km North America output to finer grids