### PR TITLE
Add option to output on RRFS-AK 3-km Lambert grid

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -309,6 +309,7 @@ if [ ${#ADDNL_OUTPUT_GRIDS[@]} -gt 0 ]; then
   grid_specs_clue="lambert:262.5:38.5 239.891:1620:3000.0 20.971:1120:3000.0"
   grid_specs_hrrr="lambert:-97.5:38.5 -122.7195:1799:3000.0 21.13812:1059:3000.0"
   grid_specs_hrrre="lambert:-97.5:38.5 -122.71953:1800:3000.0 21.138123:1060:3000.0"
+  grid_specs_rrfsak="lambert:-161.5:63.0 172.102615:1379:3000.0 45.84576:1003:3000.0"
 
   for grid in ${ADDNL_OUTPUT_GRIDS[@]}
   do

--- a/ush/config.sh.RRFS_NA_3km
+++ b/ush/config.sh.RRFS_NA_3km
@@ -98,7 +98,7 @@ NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"
 NCL_REGION="conus"
 MODEL="RRFS_NA_3km"
-ADDNL_OUTPUT_GRIDS=( "hrrr" )
+ADDNL_OUTPUT_GRIDS=( "hrrr" "rrfsak" )
 
 #
 # In NCO mode, the following don't need to be explicitly set to "FALSE" 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1539,6 +1539,7 @@ MAXTRIES_CLDANL_NONVAR="1"
 #  "clue"  (NSSL/SPC 3-km CLUE grid for 2020/2021)
 #  "hrrr"  (HRRR 3-km CONUS grid)
 #  "hrrre" (HRRRE 3-km CONUS grid)
+#  "rrfsak" (RRFS 3-km Alaska grid)
 #
 ADDNL_OUTPUT_GRIDS=( )
 #


### PR DESCRIPTION
- add grid specs for RRFS-AK to run_post script
- set config.sh file for 3-km North America runs to output on this grid in addition to the 3-km HRRR grid
- add this option to config_defaults.sh comments so users know it exists
