### PR TITLE
RRFS_ens: More changes for real-time RRFSE and a few other minor changes 

### DIFF
--- a/scripts/exregional_archive.ksh
+++ b/scripts/exregional_archive.ksh
@@ -31,7 +31,9 @@ if [[ $runcount -gt 0 ]];then
     if [[ -d ${CYCLE_BASEDIR}/$year$month$day$hour/anal_gsi ]];then
       echo "GSI Diag ..."
       mkdir -p $COMOUT_BASEDIR/stage/$year$month$day$hour/anal_gsi
+      mkdir -p $COMOUT_BASEDIR/../../../../../staged_data/$year$month$day$hour/anal_gsi
       cp -rsv ${CYCLE_BASEDIR}/$year$month$day$hour/anal_gsi/* $COMOUT_BASEDIR/stage/$year$month$day$hour/anal_gsi
+      cp -rv ${CYCLE_BASEDIR}/$year$month$day$hour/anal_gsi/* $COMOUT_BASEDIR/../../../../../staged_data/$year$month$day$hour/anal_gsi
     fi
 
     for memID in {1..9}; do
@@ -44,8 +46,10 @@ if [[ $runcount -gt 0 ]];then
         echo "GRIB-2 for ${ensmem} ..."
         mkdir -p $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd
         mkdir -p $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
+        mkdir -p $COMOUT_BASEDIR/../../../../../staged_data/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
         cp -rsv ${COMOUT_BASEDIR}/${onerun}/${ensmem}/*bg*tm* $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd 
         cp -rsv ${COMOUT_BASEDIR}/${onerun}/${ensmem}/hrrr_grid/*bg*tm* $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
+        cp -rv ${COMOUT_BASEDIR}/${onerun}/${ensmem}/hrrr_grid/*bgsfc*tm* $COMOUT_BASEDIR/../../../../../staged_data/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
       fi
 
       if [[ -e ${CYCLE_BASEDIR}/$year$month$day$hour/${ensmem}/INPUT/gfs_data.tile7.halo0.nc ]]; then

--- a/scripts/exregional_archive.ksh
+++ b/scripts/exregional_archive.ksh
@@ -2,9 +2,9 @@
 
 module load hpss
 
-day=`date -u "+%d" -d "-1 day"`
-month=`date -u "+%m" -d "-1 day"`
-year=`date -u "+%Y" -d "-1 day"`
+day=`date -u "+%d" -d "-2 day"`
+month=`date -u "+%m" -d "-2 day"`
+year=`date -u "+%Y" -d "-2 day"`
 
 . ${GLOBAL_VAR_DEFNS_FP}
 

--- a/scripts/exregional_archive.ksh
+++ b/scripts/exregional_archive.ksh
@@ -43,7 +43,9 @@ if [[ $runcount -gt 0 ]];then
       if [[ $postcount -gt 0 ]];then
         echo "GRIB-2 for ${ensmem} ..."
         mkdir -p $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd
+        mkdir -p $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
         cp -rsv ${COMOUT_BASEDIR}/${onerun}/${ensmem}/*bg*tm* $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd 
+        cp -rsv ${COMOUT_BASEDIR}/${onerun}/${ensmem}/hrrr_grid/*bg*tm* $COMOUT_BASEDIR/stage/$year$month$day$hour/${ensmem}/postprd/hrrr_grid
       fi
 
       if [[ -e ${CYCLE_BASEDIR}/$year$month$day$hour/${ensmem}/INPUT/gfs_data.tile7.halo0.nc ]]; then

--- a/scripts/exregional_clean.ksh
+++ b/scripts/exregional_clean.ksh
@@ -5,7 +5,7 @@ currentime=`date`
 . ${GLOBAL_VAR_DEFNS_FP}
 
 # Delete ptmp directories
-deletetime=`date +%Y%m%d -d "${currentime} 72 hours ago"`
+deletetime=`date +%Y%m%d -d "${currentime} 96 hours ago"`
 echo "Deleting ptmp directories before ${deletetime}..."
 cd ${COMOUT_BASEDIR}
 set -A XX `ls -d ${RUN}.20* | sort -r`
@@ -30,7 +30,7 @@ for onetime in ${XX[*]};do
 done
 
 # Delete netCDF files
-deletetime=`date +%Y%m%d%H -d "${currentime} 48 hours ago"`
+deletetime=`date +%Y%m%d%H -d "${currentime} 60 hours ago"`
 echo "Deleting netCDF files before ${deletetime}..."
 cd ${CYCLE_BASEDIR}
 set -A XX `ls -d 20* | sort -r`
@@ -45,7 +45,7 @@ for onetime in ${XX[*]};do
 done
 
 # Delete old log files
-deletetime=`date +%Y%m%d%H -d "${currentime} 72 hours ago"`
+deletetime=`date +%Y%m%d%H -d "${currentime} 96 hours ago"`
 echo "Deleting log files before ${deletetime}..."
 
 # Remove template date from last two levels

--- a/scripts/exregional_run_analysis.sh
+++ b/scripts/exregional_run_analysis.sh
@@ -516,6 +516,7 @@ done
 rm -f obs*
 rm -f pe*
 rm -f gsi.x
+rm -f fv3_grid_spec berror_stats satbias* gfs_data.tile7.halo0.nc_b
 find *.bin -maxdepth 1 -exec unlink '{}' \;
 
 #

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1257,6 +1257,7 @@ GET_EXTRN_LBCS_TN="get_extrn_lbcs"
 MAKE_ICS_TN="make_ics"
 MAKE_LBCS_TN="make_lbcs"
 RUN_FCST_TN="run_fcst"
+RUN_FCST_LONG_TN="run_fcst_long"
 RUN_POST_TN="run_post"
 
 ANAL_GSI_INPUT_TN="anal_gsi_input"
@@ -1302,7 +1303,7 @@ WTIME_GET_EXTRN_LBCS="00:45:00"
 WTIME_MAKE_ICS="00:30:00"
 WTIME_MAKE_LBCS="00:30:00"
 WTIME_RUN_FCST="04:30:00"
-WTIME_RUN_POST="00:35:00"
+WTIME_RUN_POST="00:45:00"
 #
 # Maximum number of attempts.
 #

--- a/ush/generate_FV3LAM_wflow.sh
+++ b/ush/generate_FV3LAM_wflow.sh
@@ -221,6 +221,7 @@ settings="\
   'make_ics_tn': ${MAKE_ICS_TN}
   'make_lbcs_tn': ${MAKE_LBCS_TN}
   'run_fcst_tn': ${RUN_FCST_TN}
+  'run_fcst_long_tn': ${RUN_FCST_LONG_TN}
   'run_post_tn': ${RUN_POST_TN}
   'anal_gsi_input': ${ANAL_GSI_INPUT_TN}
   'anal_gsi_restart': ${ANAL_GSI_RESTART_TN}

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -31,6 +31,7 @@ Workflow task names.
 <!ENTITY MAKE_ICS_TN       "{{ make_ics_tn }}">
 <!ENTITY MAKE_LBCS_TN      "{{ make_lbcs_tn }}">
 <!ENTITY RUN_FCST_TN       "{{ run_fcst_tn }}">
+<!ENTITY RUN_FCST_LONG_TN  "{{ run_fcst_long_tn }}">
 <!ENTITY RUN_POST_TN       "{{ run_post_tn }}">
 
 <!ENTITY ANAL_GSI_INPUT_TN    "{{ anal_gsi_input }}">
@@ -111,12 +112,17 @@ tasks; and the "FCST" type is used for the RUN_FCST_TN task.
 {%- if run_realtime %}
 <!ENTITY DEADLINE_PRE      "08:00:00">
 <!ENTITY DEADLINE_FCST     "23:30:00">
+<!ENTITY DEADLINE_FCST_00Z "12:30:00">
+<!ENTITY DEADLINE_FCST_12Z "14:15:00">
+<!ENTITY START_FCST_12Z    "06:00:00">
 <!ENTITY DEADLINE_POST     "24:00:00">
 <!ENTITY DEADLINE_GRAPHICS "24:00:00">
-<!ENTITY DEADLINE_ANAL     "36:00:00">
+<!ENTITY DEADLINE_ANAL     "42:00:00">
 
 <!ENTITY WALL_LIMIT_PRE '<deadline><cyclestr offset="&DEADLINE_PRE;">@Y@m@d@H@M</cyclestr></deadline>'>
 <!ENTITY WALL_LIMIT_FCST '<deadline><cyclestr offset="&DEADLINE_FCST;">@Y@m@d@H@M</cyclestr></deadline>'>
+<!ENTITY WALL_LIMIT_FCST_00Z '<deadline><cyclestr offset="&DEADLINE_FCST_00Z;">@Y@m@d@H@M</cyclestr></deadline>'>
+<!ENTITY WALL_LIMIT_FCST_12Z '<deadline><cyclestr offset="&DEADLINE_FCST_12Z;">@Y@m@d@H@M</cyclestr></deadline>'>
 <!ENTITY WALL_LIMIT_POST '<deadline><cyclestr offset="&DEADLINE_POST;">@Y@m@d@H@M</cyclestr></deadline>'>
 <!ENTITY WALL_LIMIT_BUFR '<deadline><cyclestr offset="&DEADLINE_POST;">@Y@m@d@H@M</cyclestr></deadline>'>
 <!ENTITY WALL_LIMIT_GRAPHICS '<deadline><cyclestr offset="&DEADLINE_GRAPHICS;">@Y@m@d@H@M</cyclestr></deadline>'>
@@ -133,7 +139,8 @@ tasks; and the "FCST" type is used for the RUN_FCST_TN task.
 {%- endif %}
 {# Double quotes are required inside the strftime! Expect an error from reading the template if using single quotes. #}
   <cycledef group="at_start">{{ cdate_first_cycl.strftime("%M %H %d %m %Y *") }}</cycledef>
-  <cycledef group="forecast">{{ cdate_first_cycl.strftime("%Y%m%d%H%M") }} {{ cdate_last_cycl.strftime("%Y%m%d%H%M") }} {{ cycl_freq }}</cycledef>
+  <cycledef group="forecast_00z">{{ cdate_first_cycl.strftime("%Y%m%d") }}0000 {{ cdate_last_cycl.strftime("%Y%m%d") }}0000 24:00:00 </cycledef>
+  <cycledef group="forecast_12z">{{ cdate_first_cycl.strftime("%Y%m%d") }}1200 {{ cdate_last_cycl.strftime("%Y%m%d") }}1200 24:00:00 </cycledef>
   <cycledef group="archive">{{ cdate_first_arch.strftime("%Y%m%d%H%M") }} {{ cdate_last_arch.strftime("%Y%m%d%H%M") }} 24:00:00</cycledef> 
 
   <log>
@@ -274,7 +281,7 @@ MODULES_RUN_TASK_FP script.
 {%- endfor %} </var>
 {%- endif %}
 
-  <task name="&GET_EXTRN_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_get_extrn_ics }}">
+  <task name="&GET_EXTRN_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_get_extrn_ics }}">
 
     &RSRV_HPSS;
   {% if run_realtime %}
@@ -316,7 +323,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&GET_EXTRN_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_get_extrn_lbcs }}">
+  <task name="&GET_EXTRN_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_get_extrn_lbcs }}">
 
     &RSRV_HPSS;
   {% if run_realtime %}
@@ -351,7 +358,7 @@ MODULES_RUN_TASK_FP script.
       <sh>
         test $(find <cyclestr offset="-{{ extrn_mdl_lbcs_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_lbcs }}{{ input_ensmem_subdir_00 }}/@y@j@H*{0{{ extrn_mdl_lbcs_offset_hrs }}..{{ ext_fcst_len_hrs }}..0{{ lbc_spec_intvl_hrs }}} \
            -mmin +5 | wc -l)</cyclestr> \
-        -gt  $(( {{ ext_fcst_len_hrs }}/{{ lbc_spec_intvl_hrs }} ))
+        -gt  $(( {{ fcst_len_hrs }}/{{ lbc_spec_intvl_hrs }} ))
       </sh>
     </dependency>
     
@@ -385,7 +392,7 @@ MODULES_RUN_TASK_FP script.
 
 {%- endif %}
 
-  <task name="&GET_EXTRN_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_get_extrn_ics }}">
+  <task name="&GET_EXTRN_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_get_extrn_ics }}">
 
     &RSRV_HPSS;
   {% if run_realtime %}
@@ -427,7 +434,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&GET_EXTRN_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_get_extrn_lbcs }}">
+  <task name="&GET_EXTRN_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_get_extrn_lbcs }}">
 
     &RSRV_HPSS;
   {% if run_realtime %}
@@ -462,7 +469,7 @@ MODULES_RUN_TASK_FP script.
       <sh>
         test $(find <cyclestr offset="-{{ extrn_mdl_lbcs_offset_hrs }}:00:00">{{ extrn_mdl_sysbasedir_lbcs }}{{ input_ensmem_subdir }}/@y@j@H*{0{{ extrn_mdl_lbcs_offset_hrs }}..{{ ext_fcst_len_hrs }}..0{{ lbc_spec_intvl_hrs }}} \
            -mmin +5 | wc -l)</cyclestr> \
-        -gt  $(( {{ ext_fcst_len_hrs }}/{{ lbc_spec_intvl_hrs }} ))
+        -gt  $(( {{ fcst_len_hrs }}/{{ lbc_spec_intvl_hrs }} ))
       </sh>
     </dependency>
     
@@ -485,7 +492,7 @@ MODULES_RUN_TASK_FP script.
 {%- endfor %} </var>
 {%- endif %}
 
-  <task name="&MAKE_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_make_ics }}">
+  <task name="&MAKE_ICS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_make_ics }}">
 
     &RSRV_DEFAULT;
   {% if run_realtime %}
@@ -531,7 +538,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&MAKE_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_make_lbcs }}">
+  <task name="&MAKE_LBCS_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_make_lbcs }}">
 
     &RSRV_DEFAULT;
   {% if run_realtime %}
@@ -577,11 +584,11 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_run_fcst }}">
+  <task name="&RUN_FCST_LONG_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z" maxtries="{{ maxtries_run_fcst }}">
 
     &RSRV_FCST;
   {% if run_realtime %}
-    &WALL_LIMIT_FCST;
+    &WALL_LIMIT_FCST_00Z;
   {% endif %}
 
     <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_FCST_TN;" "&JOBSDIR;/JREGIONAL_RUN_FCST"</command>
@@ -615,9 +622,50 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
+  <task name="&RUN_FCST_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_12z" maxtries="{{ maxtries_run_fcst }}">
+
+    &RSRV_FCST;
+  {% if run_realtime %}
+    &WALL_LIMIT_FCST_12Z;
+  {% endif %}
+
+    <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_FCST_TN;" "&JOBSDIR;/JREGIONAL_RUN_FCST"</command>
+  {% if machine in ["JET", "HERA"]  %}
+    <cores>{{ ncores_run_fcst }}</cores>
+    <native>{{ native_run_fcst }}</native>
+  {% else %}
+    <nodes>{{ nnodes_run_fcst }}:ppn={{ ppn_run_fcst }}</nodes>
+    <nodesize>&NCORES_PER_NODE;</nodesize>
+  {% endif %}
+    <walltime>{{ wtime_run_fcst }}</walltime>
+    <jobname>rrfse_&RUN_FCST_TN;{{ uscore_ensmem_name }}</jobname>
+    <join><cyclestr>&LOGDIR;/&RUN_FCST_TN;{{ uscore_ensmem_name }}_@Y@m@d@H.log</cyclestr></join>
+
+    <envar><name>GLOBAL_VAR_DEFNS_FP</name><value>&GLOBAL_VAR_DEFNS_FP;</value></envar>
+    <envar><name>PDY</name><value><cyclestr>@Y@m@d</cyclestr></value></envar>
+    <envar><name>CDATE</name><value><cyclestr>@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>CYCLE_DIR</name><value><cyclestr>&CYCLE_BASEDIR;/@Y@m@d@H</cyclestr></value></envar>
+    <envar><name>SLASH_ENSMEM_SUBDIR</name><value><cyclestr>{{ slash_ensmem_subdir }}</cyclestr></value></envar>
+    <envar><name>ENSMEM_INDX</name><value><cyclestr>#{{ ensmem_indx_name }}#</cyclestr></value></envar>
+  
+    <dependency>
+      <and>
+    {%- if run_realtime %}
+        <timedep><cyclestr offset="&START_FCST_12Z;">@Y@m@d@H@M00</cyclestr></timedep>
+    {%- endif %}
+        <taskdep task="&MAKE_ICS_TN;{{ uscore_ensmem_name }}"/>
+        <taskdep task="&MAKE_LBCS_TN;{{ uscore_ensmem_name }}"/>
+      </and>
+    </dependency>
+
+  </task>
+<!--
+************************************************************************
+************************************************************************
+-->
   <metatask name="&RUN_POST_TN;{{ uscore_ensmem_name }}">
     <var name="fhr"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %03d" % h  }}{% endfor %} </var>
-    <task name="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+    <task name="&RUN_POST_TN;{{ uscore_ensmem_name }}_f#fhr#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
       &RSRV_DEFAULT;
     {% if run_realtime %}
@@ -656,7 +704,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&CLEAN_TN;{{ uscore_ensmem_name }}" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+  <task name="&CLEAN_TN;{{ uscore_ensmem_name }}" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
     &RSRV_DEFAULT;
 
@@ -684,10 +732,10 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-  <task name="&ANAL_GSI_INPUT_TN;" cycledefs="forecast" maxtries="{{ maxtries_anal_gsi }}">
+  <task name="&ANAL_GSI_INPUT_TN;" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_anal_gsi }}">
 
      &RSRV_DEFAULT;
-<!--     &WALL_LIMIT_ANAL;  -->
+     &WALL_LIMIT_ANAL;  
 
      <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ANAL_TN;" "&JOBSDIR;/JREGIONAL_RUN_ANAL"</command>
      <cores>240</cores>
@@ -722,10 +770,10 @@ MODULES_RUN_TASK_FP script.
 -->
 <metatask name="anal_gsi"> 
 <var name="fhr"> {% for h in range(3, 25, 3) %}{{ " %02d" % h  }}{% endfor %} </var>
-   <task name="&ANAL_GSI_RESTART_TN;_f#fhr#" cycledefs="forecast" maxtries="{{ maxtries_anal_gsi }}">
+   <task name="&ANAL_GSI_RESTART_TN;_f#fhr#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_anal_gsi }}">
 
      &RSRV_DEFAULT;
-<!--     &WALL_LIMIT_ANAL; --> 
+     &WALL_LIMIT_ANAL; 
 
      <command>&LOAD_MODULES_RUN_TASK_FP; "&RUN_ANAL_TN;" "&JOBSDIR;/JREGIONAL_RUN_ANAL"</command>
      <cores>240</cores>
@@ -765,7 +813,7 @@ MODULES_RUN_TASK_FP script.
 <metatask name="plot_fcst">
 <var name="fcstsec"> {% for h in range(0, fcst_len_hrs+1) %}{{ 3600 * h }} {% endfor %} </var>
 <var name="fcsthour"> {% for h in range(0, fcst_len_hrs+1) %}{{ " %02d" % h  }}{% endfor %} </var>
-    <task name="ncl_fcst_#fcsthour#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+    <task name="ncl_fcst_#fcsthour#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
       &NCL_MAIN_RESOURCES;
       &RSRV_DEFAULT;
@@ -800,7 +848,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-    <task name="ncl_ens9_#fcsthour#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+    <task name="ncl_ens9_#fcsthour#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
       &NCL_MAIN_RESOURCES;
       &RSRV_DEFAULT;
@@ -835,7 +883,7 @@ MODULES_RUN_TASK_FP script.
 ************************************************************************
 ************************************************************************
 -->
-    <task name="py_max_#fcsthour#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+    <task name="py_max_#fcsthour#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
       &NCL_MAIN_RESOURCES;
       &RSRV_DEFAULT;
@@ -869,7 +917,7 @@ only checking for sfc here, and assuming that bgdawp are also available -->
 -->
 <metatask name="zip_part1" mode="serial">
    <var name="fcsthour">00</var>
-   <task name="ncl_zip_#fcsthour#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+   <task name="ncl_zip_#fcsthour#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
       &NCL_MAIN_RESOURCES;
       &RSRV_DEFAULT;
@@ -897,7 +945,7 @@ only checking for sfc here, and assuming that bgdawp are also available -->
 -->
 <metatask name="zip_part2" mode="serial">
    <var name="fcsthour"> {% for h in range(1, fcst_len_hrs+1) %}{{ " %02d" % h  }}{% endfor %} </var>
-    <task name="ncl_zip_#fcsthour#" cycledefs="forecast" maxtries="{{ maxtries_run_post }}">
+    <task name="ncl_zip_#fcsthour#" cycledefs="forecast_00z,forecast_12z" maxtries="{{ maxtries_run_post }}">
 
      &NCL_MAIN_RESOURCES;
      &RSRV_DEFAULT;
@@ -920,7 +968,6 @@ only checking for sfc here, and assuming that bgdawp are also available -->
 
      </task>
 </metatask>
-
 <!--
 ************************************************************************
 ************************************************************************

--- a/ush/templates/FV3LAM_wflow.xml
+++ b/ush/templates/FV3LAM_wflow.xml
@@ -133,7 +133,7 @@ tasks; and the "FCST" type is used for the RUN_FCST_TN task.
 ]>
 
 {%- if run_realtime %}
-<workflow realtime="T" scheduler="&SCHED;" cyclethrottle="15" cyclelifespan="02:00:00:00">
+<workflow realtime="T" scheduler="&SCHED;" cyclethrottle="15" cyclelifespan="03:00:00:00">
 {%- else %}
 <workflow realtime="F" scheduler="&SCHED;" cyclethrottle="15" >
 {%- endif %}
@@ -978,7 +978,7 @@ only checking for sfc here, and assuming that bgdawp are also available -->
 
     <command>&JOBSDIR;/../scripts/exregional_archive.ksh</command>
     <cores>1</cores>
-    <walltime>08:00:00</walltime>
+    <walltime>23:40:00</walltime>
     <memory>24G</memory>
     <jobname>rrfse_&ARCHIVE_TN;</jobname>
     <join><cyclestr>&LOGDIR;/&ARCHIVE_TN;_@Y@m@d@H.log</cyclestr></join>

--- a/ush/templates/input.nml.FV3
+++ b/ush/templates/input.nml.FV3
@@ -142,7 +142,7 @@
     do_skeb = .false.
     do_sppt = .false.
     dspheat = .true.
-    fhcyc = 24.0
+    fhcyc = 72.0
     fhlwr = 1200.0
     fhswr = 1200.0
     fhzero = 1.0


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
- Changes to the workflow to be what is now in real-time RRFSE, including the 00Z and 12Z forecast deadline and start time; No more manual changes needed when deployed in real-time
- Fix the bug for the LBCs file count
- Extend the wall-limit for post job
- Change fhcyc to 72 hrs, following the suggestion from Tanya, in order not to overwrite surface parameters with the climatological values
- Add archiving of the GRIB-2 files on the HRRR grid
 
## TESTS CONDUCTED: 
Most already in real-time RRFSE. Tested in my own space.

## ISSUE (optional): 

## CONTRIBUTORS (optional): 
@tanyasmirnova 

