### PR TITLE
Changes to exregional_run_post.sh to enable comparison of QPF vs. gridded flash flood guidance

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -176,11 +176,13 @@ cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
 cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
 cp_vrfy ${EXECDIR}/ncep_post .
 cp_vrfy ${FFG_DIR}/latest.FFG .
-grid_specs_rrfs="lambert:-97.5:38.500000 237.826400:1746:3000 21.88589:1014:3000"
-wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2
-wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
-wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2
-wgrib2 latest.FFG -match "0-1 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_01h.grib2
+if [ ${NET} = "RRFS_CONUS" ]; then
+  grid_specs_rrfs="lambert:-97.5:38.500000 237.826400:1746:3000 21.88589:1014:3000"
+  wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2
+  wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
+  wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2
+  wgrib2 latest.FFG -match "0-1 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_01h.grib2
+fi
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -175,6 +175,12 @@ fi
 cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
 cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
 cp_vrfy ${EXECDIR}/ncep_post .
+cp_vrfy ${FFG_DIR}/latest.FFG .
+grid_specs_rrfs="lambert:-97.5:38.500000 237.826400:1746:3000 21.88589:1014:3000"
+wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2
+wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
+wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2
+wgrib2 latest.FFG -match "0-1 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_01h.grib2
 #
 #-----------------------------------------------------------------------
 #

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -177,7 +177,7 @@ cp_vrfy ${EMC_POST_DIR}/parm/params_grib2_tbl_new ./params_grib2_tbl_new
 cp_vrfy ${EXECDIR}/ncep_post .
 cp_vrfy ${FFG_DIR}/latest.FFG .
 if [ ${NET} = "RRFS_CONUS" ]; then
-  grid_specs_rrfs="lambert:-97.5:38.500000 237.826400:1746:3000 21.88589:1014:3000"
+  grid_specs_rrfs="lambert:-97.5:38.500000 237.826355:1746:3000 21.885885:1014:3000"
   wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2
   wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
   wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2

--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -20,6 +20,7 @@ GWD_HRRRsuite_BASEDIR=/mnt/lfs4/BMC/nrtrr/RRFS/fix/fix_lam.20210128
 FIX_GSI=/mnt/lfs4/BMC/nrtrr/RRFS/fix/fix_gsi
 FIX_CRTM=/home/rtrr/FIX_EXEC_MODULE/crtm/CRTM_v2.3.0
 OBSPATH_NSSLMOSIAC=/public/data/radar/nssl/mrms/conus
+FFG_DIR=/public/data/grids/ncep/ffg/grib2
 RADARREFL_TIMELEVEL=(0 15 30 45)
 FH_DFI_RADAR="0.0,0.25,0.5"
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -245,6 +245,7 @@ EXPT_SUBDIR=""
 #    OBSPATH_NSSLMOSIAC: location of NSSL radar reflectivity 
 #    LIGHTNING_ROOT: location of lightning observations
 #    ENKF_FCSTL: location of global ensemble forecast
+#    FFG_DIR: location of flash flood guidance for QPF comparison
 #-----------------------------------------------------------------------
 #
 COMINgfs="/base/path/of/directory/containing/gfs/input/files"
@@ -266,6 +267,7 @@ OBSPATH="/public/data/grids/rap/obs"
 OBSPATH_NSSLMOSIAC="/public/data/radar/mrms"
 LIGHTNING_ROOT="/public/data/lightning"
 ENKF_FCST="/lfs4/BMC/public/data/grids/enkf/atm"
+FFG_DIR="/public/data/grids/ncep/ffg/grib2"
 
 #
 #-----------------------------------------------------------------------


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
For our Hurricane Supplemental Project on QPF post-processing, we need to output GRIB2 records showing forecast points where model QPF exceeds Flash Flood Guidance (FFG).  This code was working in HRRRX but never got transitioned to operational HRRR.  Most of the code changes are in EMC_POST (a separate pull request), but this pull request has modifications to exregional_run_post.sh to (1) copy in latest realtime FFG files to the post run directory, and (2) interpolate the FFG to the RRFS grid for comparison.  

## TESTS CONDUCTED: 
The EMC_POST update was tested in combination this update on Jet in a full RRFS-dev1 like deployment in my directory.   