### PR TITLE
RRFS_dev2: Bug fix for using GDAS ens

### DIFF
--- a/scripts/exregional_run_analysis.sh
+++ b/scripts/exregional_run_analysis.sh
@@ -246,6 +246,7 @@ case $MACHINE in
   done
 
   if [ $foundens ]; then
+    enkfcstname=gdas
     ls ${ENKF_FCST}/${enkfcstname}.mem0??.${ens_type} >> filelist03
   fi
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -559,7 +559,7 @@ BERROR_FN="rap_berror_stats_global_RAP_tune" #under $FIX_GSI
 OBERROR_FN="errtable.rrfs"
 HYBENSINFO_FN="hybens_info.rrfs"
 AIRCRAFT_REJECT="/home/amb-verif/acars_RR/amdar_reject_lists"
-SFCOBS_USELIST="/home/amb-verif/ruc_madis_surface/mesonet_uselists"
+SFCOBS_USELIST="/lfs4/BMC/amb-verif/rap_ops_mesonet_uselists"
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
When GDAS ensembles are missing, the GSI run scripts will crash. Fix this bug.
Also add right link to surface mesonet uselist.