### PR TITLE
Allow earlier purging of GRIB-2 files in STMP to conserve space

### DIFF
--- a/scripts/exregional_clean.ksh
+++ b/scripts/exregional_clean.ksh
@@ -67,6 +67,20 @@ for onetime in ${XX[*]};do
 done
 
 #-----------------------------------------------------------------------
+# Delete duplicate postprod files in stmp
+#-----------------------------------------------------------------------
+deletetime=$(date +%Y%m%d%H -d "${currentime} ${CLEAN_OLDSTMPPOST_HRS} hours ago")
+echo "Deleting stmp postprd files before ${deletetime}..."
+cd ${CYCLE_BASEDIR}
+set -A XX $(ls -d 20* | sort -r)
+for onetime in ${XX[*]};do
+  if [[ ${onetime} -le ${deletetime} ]]; then
+    rm -rf ${CYCLE_BASEDIR}/${onetime}/postprd
+    echo "Deleted postprd files in ${CYCLE_BASEDIR}/${onetime}/postprd"
+  fi
+done
+
+#-----------------------------------------------------------------------
 # Delete old log files
 #-----------------------------------------------------------------------
 deletetime=$(date +%Y%m%d%H -d "${currentime} ${CLEAN_OLDLOG_HRS} hours ago")

--- a/ush/config.sh.3DRTMA_dev1
+++ b/ush/config.sh.3DRTMA_dev1
@@ -234,6 +234,7 @@ if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config.sh.RRFS_AK_dev1
+++ b/ush/config.sh.RRFS_AK_dev1
@@ -161,6 +161,7 @@ if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config.sh.RRFS_NA_13km
+++ b/ush/config.sh.RRFS_NA_13km
@@ -163,6 +163,7 @@ if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config.sh.RRFS_NA_3km
+++ b/ush/config.sh.RRFS_NA_3km
@@ -171,6 +171,7 @@ if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -1,7 +1,7 @@
 MACHINE="jet"
 ACCOUNT="nrtrr"
 RESERVATION="rrfsdet"
-EXPT_BASEDIR="/home/rtrr/RRFS"
+EXPT_BASEDIR="/lfs4/BMC/nrtrr/talcott/rrfs/rt"
 EXPT_SUBDIR="RRFS_dev1"
 
 if [[ -n $RESERVATION ]] ; then
@@ -177,14 +177,15 @@ MODEL="RRFS_dev1"
 RUN="RRFS_dev1"
 COMINgfs=""
 
-STMP="/lfs4/BMC/nrtrr/NCO_dirs/stmp"  # Path to directory STMP that mostly contains input files.
-PTMP="/lfs4/BMC/nrtrr/NCO_dirs/ptmp"  # Path to directory STMP that mostly contains input files.
+STMP="/lfs4/BMC/nrtrr/talcott/rrfs/stmp"  # Path to directory STMP that mostly contains input files.
+PTMP="/lfs4/BMC/nrtrr/talcott/rrfs/ptmp"  # Path to directory STMP that mostly contains input files.
 
 if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDPROD_HRS="240"
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config.sh.RRFS_dev1
+++ b/ush/config.sh.RRFS_dev1
@@ -1,7 +1,7 @@
 MACHINE="jet"
 ACCOUNT="nrtrr"
 RESERVATION="rrfsdet"
-EXPT_BASEDIR="/lfs4/BMC/nrtrr/talcott/rrfs/rt"
+EXPT_BASEDIR="/home/rtrr/RRFS"
 EXPT_SUBDIR="RRFS_dev1"
 
 if [[ -n $RESERVATION ]] ; then
@@ -177,8 +177,8 @@ MODEL="RRFS_dev1"
 RUN="RRFS_dev1"
 COMINgfs=""
 
-STMP="/lfs4/BMC/nrtrr/talcott/rrfs/stmp"  # Path to directory STMP that mostly contains input files.
-PTMP="/lfs4/BMC/nrtrr/talcott/rrfs/ptmp"  # Path to directory STMP that mostly contains input files.
+STMP="/lfs4/BMC/nrtrr/NCO_dirs/stmp"  # Path to directory STMP that mostly contains input files.
+PTMP="/lfs4/BMC/nrtrr/NCO_dirs/ptmp"  # Path to directory STMP that mostly contains input files.
 
 if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDPROD_HRS="240"

--- a/ush/config.sh.RRFS_wcoss
+++ b/ush/config.sh.RRFS_wcoss
@@ -139,6 +139,7 @@ if [[ $DO_RETRO == "true" ]] ; then
   CLEAN_OLDLOG_HRS="240"
   CLEAN_OLDRUN_HRS="6"
   CLEAN_OLDFCST_HRS="6"
+  CLEAN_OLDSTMPPOST_HRS="6"
   if [[ $LBCS_ICS_ONLY == "true" ]]; then
     CLEAN_OLDRUN_HRS="7777"
     CLEAN_OLDFCST_HRS="7777"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1796,6 +1796,8 @@ RADARREFL_TIMELEVEL=(0)
 #   the run directory under tmpnwprd directory from cycles older than (current cycle - this hour) will be cleaned 
 # CLEAN_OLDFCST_HRS
 #   the fv3lam forecast netcdf files forecast run directory from cycles older than (current cycle - this hour) will be cleaned 
+# CLEAN_OLDSTMP_HRS
+#   the postprd GRIB-2 files from cycles older than (current cycle - this hour) will be cleaned 
 #-----------------------------------------------------------------------
 #
 
@@ -1803,3 +1805,4 @@ CLEAN_OLDPROD_HRS="72"
 CLEAN_OLDLOG_HRS="48"
 CLEAN_OLDRUN_HRS="72"
 CLEAN_OLDFCST_HRS="24"
+CLEAN_OLDSTMPPOST_HRS="24"


### PR DESCRIPTION
- creates a new variable to specifically purge GRIB-2 files in STMP earlier than other forecast files
- setting to 24 hours frees up ~5 TB of space just for CONUS dev1 runs
- tested on real-time CONUS dev1 run