### PR TITLE
Changes to exregional_run_post.sh to handle interpolating FFG to the 3km NA RRFS domain.

### DIFF
--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -192,6 +192,13 @@ if [ -f ${FFG_DIR}/latest.FFG ] && [ ${NET} = "RRFS_CONUS" ]; then
   wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
   wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2
   wgrib2 latest.FFG -match "0-1 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_01h.grib2
+elif [ -f ${FFG_DIR}/latest.FFG ] && [ ${NET} = "RRFS_NA_3km" ]; then
+  cp_vrfy ${FFG_DIR}/latest.FFG .
+  grid_specs_rrfs="rot-ll:248.000000:-42.000000:0.000000 309.000000:4081:0.025000 -33.0000000:2641:0.025000"
+  wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2
+  wgrib2 latest.FFG -match "0-6 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_06h.grib2
+  wgrib2 latest.FFG -match "0-3 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_03h.grib2
+  wgrib2 latest.FFG -match "0-1 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_01h.grib2
 fi
 #
 #-----------------------------------------------------------------------

--- a/ush/config.sh.RRFS_NA_3km
+++ b/ush/config.sh.RRFS_NA_3km
@@ -46,6 +46,7 @@ if [[ $MACHINE == "hera" ]] ; then
 # observations
   OBSPATH=/scratch2/BMC/public/data/grids/rap/obs
   OBSPATH_NSSLMOSIAC=/scratch2/BMC/public/data/radar/nssl/mrms/conus
+  FFG_DIR=/public/data/grids/ncep/ffg/grib2
   LIGHTNING_ROOT=/scratch2/BMC/public/data/lightning
   ENKF_FCST=/scratch1/NCEPDEV/rstprod/com/gfs/prod
 fi


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Updating exregional_run_post.sh to add an if statement for the RRFS_3km_NA domain, to allow interpolation of flash flood guidance (FFG) files to that large rotated-lat-lon domain.  Also added the FFG_DIR variable to config.sh.RRFS_NA_3km.  NOTE: There is a corresponding minor code change to EMC_POST to enable the interpolation...see parallel EMC_POST PR.

## TESTS CONDUCTED: 
I built a stand-alone RRFS_NA_3km system on Jet and ran post jobs retrospectively for RRFS_NA_3km forecasts to ensure the FFG exceedance gridding was working as intended.

