### PR TITLE
Updating UPP fixed file paths.

### DIFF
--- a/ush/config.sh.RRFS_NA_3km
+++ b/ush/config.sh.RRFS_NA_3km
@@ -145,8 +145,8 @@ TAG="RRFS_dev1_NA_3km"
 
 USE_CUSTOM_POST_CONFIG_FILE="TRUE"
 # Below:  use EMC_post control file from 13-km NA configuration (provisional only)
-CUSTOM_POST_CONFIG_FP="/mnt/lfs4/BMC/nrtrr/RRFS/dev1-ufs-srweather-app/src/EMC_post/parm/postxconfig-NT-fv3lam_rrfs.txt"
-CUSTOM_POST_PARAMS_FP="/mnt/lfs4/BMC/nrtrr/RRFS/dev1-ufs-srweather-app/src/EMC_post/parm/params_grib2_tbl_new"
+CUSTOM_POST_CONFIG_FP="/mnt/lfs4/BMC/nrtrr/RRFS/fix/fix_upp/postxconfig-NT-fv3lam_rrfs.txt"
+CUSTOM_POST_PARAMS_FP="/mnt/lfs4/BMC/nrtrr/RRFS/fix/fix_upp/params_grib2_tbl_new"
 ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_na_3km_dev1"
 NCARG_ROOT="/apps/ncl/6.5.0-CentOS6.10_64bit_nodap_gnu447"
 NCL_HOME="/home/rtrr/RRFS/graphics"


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
These changes to config.sh.RRFS_NA_3km point to a new directory on Jet which contains updated postxconfig-NT.txt file and params_tbl file for UPP.  These files will now output all 65 vertical levels in full 3D output; old static files only output 64 vertical levels.

## TESTS CONDUCTED: 
I tested generating the RRFS_NA_3km workflow on Jet with the updated configure file.
