### PR TITLE
Updating UPP fix files

### DIFF
--- a/fix/upp/fv3lam_rrfs.xml
+++ b/fix/upp/fv3lam_rrfs.xml
@@ -388,7 +388,9 @@
        <param>
        <shortname>TSOIL_ON_DEPTH_BEL_LAND_SFC</shortname>
        <pname>TSOIL</pname>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
        <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2>
        <scale>4.0</scale>
        </param>
@@ -396,7 +398,9 @@
        <param>
        <shortname>SOILW_ON_DEPTH_BEL_LAND_SFC</shortname>
        <pname>SOILW</pname>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
        <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2>
        <scale>3.0</scale>
        </param>
@@ -1646,14 +1650,14 @@
        </param>
 
        <param>
-       <shortname>MAX_MAXUVV_ON_ISOBARIC_SFC_10-100hpa</shortname>
+       <shortname>MAX_MAXUVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
        <pname>MAXUVV</pname>
        <table_info>NCEP</table_info>
        <scale>-3.0</scale>
        </param>
 
        <param>
-       <shortname>MAX_MAXDVV_ON_ISOBARIC_SFC_10-100hpa</shortname>
+       <shortname>MAX_MAXDVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
        <pname>MAXDVV</pname>
        <table_info>NCEP</table_info>
        <scale>-3.0</scale>
@@ -2055,14 +2059,14 @@
        </param>
 
        <param>
-       <shortname>MAX_MAXUVV_ON_ISOBARIC_SFC_10-100hpa</shortname>
+       <shortname>MAX_MAXUVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
        <pname>MAXUVV</pname>
        <table_info>NCEP</table_info>
        <scale>-3.0</scale>
        </param>
  
        <param>
-       <shortname>MAX_MAXDVV_ON_ISOBARIC_SFC_10-100hpa</shortname>
+       <shortname>MAX_MAXDVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
        <pname>MAXDVV</pname>
        <table_info>NCEP</table_info>
        <scale>-3.0</scale>
@@ -2178,7 +2182,9 @@
        <param>
        <shortname>TSOIL_ON_DEPTH_BEL_LAND_SFC</shortname>
        <pname>TSOIL</pname>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
        <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2>
        <scale>4.0</scale>
        </param>
@@ -2186,7 +2192,9 @@
        <param>
        <shortname>SOILW_ON_DEPTH_BEL_LAND_SFC</shortname>
        <pname>SOILW</pname>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
        <level>0. 1. 4. 10. 30. 60. 100. 160. 300.</level>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
        <level2>0. 1. 4. 10. 30. 60. 100. 160. 300.</level2>
        <scale>3.0</scale>
        </param>

--- a/fix/upp/post_avblflds.xml
+++ b/fix/upp/post_avblflds.xml
@@ -1,0 +1,7939 @@
+<?xml version="1.0"?>
+<postxml xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="EMC_POST_Avblflds_Schema.xsd">
+<!--  Lin Gan:  20150324 validated -->
+  <post_avblflds>
+
+    <param>
+       <post_avblfldidx>1</post_avblfldidx>
+       <shortname>PRES_ON_HYBRID_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>2</post_avblfldidx>
+       <shortname>TMP_ON_HYBRID_LVL</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>3</post_avblfldidx>
+       <shortname>POT_ON_HYBRID_LVL</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>4</post_avblfldidx>
+       <shortname>DPT_ON_HYBRID_LVL</shortname>
+       <pname>DPT</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>5</post_avblfldidx>
+       <shortname>SPFH_ON_HYBRID_LVL</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>7.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>6</post_avblfldidx>
+       <shortname>RH_ON_HYBRID_LVL</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>7</post_avblfldidx>
+       <shortname>UGRD_ON_HYBRID_LVL</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>8</post_avblfldidx>
+       <shortname>VGRD_ON_HYBRID_LVL</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>9</post_avblfldidx>
+       <shortname>VVEL_ON_HYBRID_LVL</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>10</post_avblfldidx>
+       <shortname>ABSV_ON_HYBRID_LVL</shortname>
+       <pname>ABSV</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>11</post_avblfldidx>
+       <shortname>TKE_ON_HYBRID_LVL</shortname>
+       <pname>TKE</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>12</post_avblfldidx>
+       <shortname>HGT_ON_ISOBARIC_SFC</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>13</post_avblfldidx>
+       <shortname>TMP_ON_ISOBARIC_SFC</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>14</post_avblfldidx>
+       <shortname>POT_ON_ISOBARIC_SFC</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>15</post_avblfldidx>
+       <shortname>DPT_ON_ISOBARIC_SFC</shortname>
+       <pname>DPT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>16</post_avblfldidx>
+       <shortname>SPFH_ON_ISOBARIC_SFC</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>17</post_avblfldidx>
+       <shortname>RH_ON_ISOBARIC_SFC</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>18</post_avblfldidx>
+       <shortname>UGRD_ON_ISOBARIC_SFC</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>19</post_avblfldidx>
+       <shortname>VGRD_ON_ISOBARIC_SFC</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>20</post_avblfldidx>
+       <shortname>VVEL_ON_ISOBARIC_SFC</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>21</post_avblfldidx>
+       <shortname>ABSV_ON_ISOBARIC_SFC</shortname>
+       <pname>ABSV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>22</post_avblfldidx>
+       <shortname>TKE_ON_ISOBARIC_SFC</shortname>
+       <pname>TKE</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>23</post_avblfldidx>
+       <shortname>MSLET_ON_MEAN_SEA_LVL</shortname>
+       <pname>MSLET</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>mean_sea_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>24</post_avblfldidx>
+       <shortname>PRES_ON_SURFACE</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>25</post_avblfldidx>
+       <shortname>HGT_ON_SURFACE</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>26</post_avblfldidx>
+       <shortname>TMP_ON_SURFACE</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>27</post_avblfldidx>
+       <shortname>POT_ON_SURFACE</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>28</post_avblfldidx>
+       <shortname>SPFH_ON_SURFACE</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>29</post_avblfldidx>
+       <shortname>DPT_ON_SURFACE</shortname>
+       <pname>DPT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>30</post_avblfldidx>
+       <shortname>LFTX_ON_ISOBARIC_SFC_500-1000hpa</shortname>
+       <pname>LFTX</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <level>50000.</level>
+       <fixed_sfc2_type>isobaric_sfc</fixed_sfc2_type>
+       <level2>100000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>31</post_avblfldidx>
+       <shortname>4LFTX_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>4LFTX</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>32</post_avblfldidx>
+       <shortname>CAPE_ON_SURFACE</shortname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>33</post_avblfldidx>
+       <shortname>ACM_ACPCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ACPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>34</post_avblfldidx>
+       <shortname>ACM_NCPCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NCPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>35</post_avblfldidx>
+       <shortname>ACM_WEASD_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>WEASD</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>36</post_avblfldidx>
+       <shortname>SOILM_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>SOILM</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>37</post_avblfldidx>
+       <shortname>LCDC_ON_LOW_CLOUD_LYR</shortname>
+       <pname>LCDC</pname>
+       <fixed_sfc1_type>low_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>38</post_avblfldidx>
+       <shortname>MCDC_ON_MID_CLOUD_LYR</shortname>
+       <pname>MCDC</pname>
+       <fixed_sfc1_type>mid_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>39</post_avblfldidx>
+       <shortname>HCDC_ON_HIGH_CLOUD_LYR</shortname>
+       <pname>HCDC</pname>
+       <fixed_sfc1_type>high_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>40</post_avblfldidx>
+       <shortname>SWHR_ON_HYBRID_LVL</shortname>
+       <pname>SWHR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>41</post_avblfldidx>
+       <shortname>LWHR_ON_HYBRID_LVL</shortname>
+       <pname>LWHR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>42</post_avblfldidx>
+       <shortname>AVE_LHTFL_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>LHTFL</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>43</post_avblfldidx>
+       <shortname>AVE_SHTFL_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SHTFL</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>44</post_avblfldidx>
+       <shortname>SFCR_ON_SURFACE</shortname>
+       <pname>SFCR</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>2.7</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>45</post_avblfldidx>
+       <shortname>FRICV_ON_SURFACE</shortname>
+       <pname>FRICV</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>46</post_avblfldidx>
+       <shortname>AVE_MFLX_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MFLX</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>47</post_avblfldidx>
+       <shortname>ACM_EVP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>EVP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>48</post_avblfldidx>
+       <shortname>NLAT_ON_SURFACE</shortname>
+       <pname>NLAT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>49</post_avblfldidx>
+       <shortname>ELON_ON_SURFACE</shortname>
+       <pname>ELON</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>50</post_avblfldidx>
+       <shortname>LAND_ON_SURFACE</shortname>
+       <pname>LAND</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>51</post_avblfldidx>
+       <shortname>ICEC_ON_SURFACE</shortname>
+       <pname>ICEC</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>52</post_avblfldidx>
+       <shortname>LMH_ON_SURFACE</shortname>
+       <pname>LMH</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>53</post_avblfldidx>
+       <shortname>LMV_ON_SURFACE</shortname>
+       <pname>LMV</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>54</post_avblfldidx>
+       <shortname>PRES_ON_TROPOPAUSE</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>55</post_avblfldidx>
+       <shortname>TMP_ON_TROPOPAUSE</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>56</post_avblfldidx>
+       <shortname>UGRD_ON_TROPOPAUSE</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>57</post_avblfldidx>
+       <shortname>VGRD_ON_TROPOPAUSE</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>58</post_avblfldidx>
+       <shortname>VWSH_ON_TROPOPAUSE</shortname>
+       <pname>VWSH</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>59</post_avblfldidx>
+       <shortname>TMP_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>60</post_avblfldidx>
+       <shortname>UGRD_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>61</post_avblfldidx>
+       <shortname>VGRD_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>62</post_avblfldidx>
+       <shortname>HGT_ON_0C_ISOTHERM</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>0C_isotherm</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>63</post_avblfldidx>
+       <shortname>RH_ON_0C_ISOTHERM</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>0C_isotherm</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>64</post_avblfldidx>
+       <shortname>UGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>65</post_avblfldidx>
+       <shortname>VGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>66</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.33-1.0</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>33.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>67</post_avblfldidx>
+       <shortname>PRES_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>68</post_avblfldidx>
+       <shortname>TMP_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>69</post_avblfldidx>
+       <shortname>POT_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>70</post_avblfldidx>
+       <shortname>DPT_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>DPT</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>71</post_avblfldidx>
+       <shortname>SPFH_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>72</post_avblfldidx>
+       <shortname>RH_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>73</post_avblfldidx>
+       <shortname>UGRD_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>74</post_avblfldidx>
+       <shortname>VGRD_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>75</post_avblfldidx>
+       <shortname>PLI_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>PLI</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>76</post_avblfldidx>
+       <shortname>RH_ON_SURFACE</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>77</post_avblfldidx>
+       <shortname>HGT_ON_HYBRID_LVL</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>78</post_avblfldidx>
+       <shortname>AVE_LRGHR_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>LRGHR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>79</post_avblfldidx>
+       <shortname>AVE_CNVHR_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CNVHR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>2.7</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>80</post_avblfldidx>
+       <shortname>PWAT_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>PWAT</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>81</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.66-1.0</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>66.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>82</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.33-0.66</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>33.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>66.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>83</post_avblfldidx>
+       <shortname>MCONV_ON_HYBRID_LVL</shortname>
+       <pname>MCONV</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>84</post_avblfldidx>
+       <shortname>STRM_ON_HYBRID_LVL</shortname>
+       <pname>STRM</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>85</post_avblfldidx>
+       <shortname>MCONV_ON_ISOBARIC_SFC</shortname>
+       <pname>MCONV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>86</post_avblfldidx>
+       <shortname>STRM_ON_ISOBARIC_SFC</shortname>
+       <pname>STRM</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>87</post_avblfldidx>
+       <shortname>ACM_APCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>APCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>88</post_avblfldidx>
+       <shortname>MCONV_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>MCONV</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>89</post_avblfldidx>
+       <shortname>PWAT_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>PWAT</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>90</post_avblfldidx>
+       <shortname>VVEL_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>91</post_avblfldidx>
+       <shortname>PRES_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>92</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>93</post_avblfldidx>
+       <shortname>SPFH_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>94</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>95</post_avblfldidx>
+       <shortname>UGRD_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>96</post_avblfldidx>
+       <shortname>VGRD_ON_SIGMA_LVL_0.98230</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>98230.</level>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>97</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVL_0.89671</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>89671.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>98</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVL_0.78483</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>5</scale_fact_fixed_sfc1>
+       <level>78483.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>99</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.47_1.0</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>47.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>100</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.47_0.96</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>47.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>96.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>101</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.18_0.47</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>18.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>47.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>102</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.84_0.98</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>84.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>98.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>103</post_avblfldidx>
+       <shortname>MCONV_ON_SIGMA_LVL_0.85_1.0</shortname>
+       <pname>MCONV</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>85.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>104</post_avblfldidx>
+       <shortname>PWAT_ON_SIGMA_LVL_0.33_1.0</shortname>
+       <pname>PWAT</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>33.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>105</post_avblfldidx>
+       <shortname>PRES_ON_MEAN_SEA_LVL</shortname>
+       <pname>PRMSL</pname>
+       <fixed_sfc1_type>mean_sea_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>106</post_avblfldidx>
+       <shortname>TMP_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>107</post_avblfldidx>
+       <shortname>CIN_ON_SURFACE</shortname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>108</post_avblfldidx>
+       <shortname>POT_ON_TROPOPAUSE</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>109</post_avblfldidx>
+       <shortname>HGT_ON_LVL_OF_ADIAB_COND_FROM_SFC</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>lvl_of_adiab_cond_from_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>110</post_avblfldidx>
+       <shortname>PRES_ON_LVL_OF_ADIAB_COND_FROM_SFC</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>lvl_of_adiab_cond_from_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>111</post_avblfldidx>
+       <shortname>RI_ON_HYBRID_LVL</shortname>
+       <pname>RI</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>112</post_avblfldidx>
+       <shortname>SPFH_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>113</post_avblfldidx>
+       <shortname>DPT_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>DPT</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>114</post_avblfldidx>
+       <shortname>RH_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>115</post_avblfldidx>
+       <shortname>TSOIL_ON_DEPTH_BEL_LAND_SFC_3m</shortname>
+       <pname>TSOIL</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <level>3.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>116</post_avblfldidx>
+       <shortname>TSOIL_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>TSOIL</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>117</post_avblfldidx>
+       <shortname>SOILW_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>SOILW</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>118</post_avblfldidx>
+       <shortname>CNWAT_ON_SURFACE</shortname>
+       <pname>CNWAT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>119</post_avblfldidx>
+       <shortname>WEASD_ON_SURFACE</shortname>
+       <pname>WEASD</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>120</post_avblfldidx>
+       <shortname>SNOWC_ON_SURFACE</shortname>
+       <pname>SNOWC</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>121</post_avblfldidx>
+       <shortname>ACM_SNOM_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SNOM</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>122</post_avblfldidx>
+       <shortname>ACM_SSRUN_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SSRUN</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>123</post_avblfldidx>
+       <shortname>ACM_BGRUN_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>BGRUN</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>124</post_avblfldidx>
+       <shortname>CLMR_ON_HYBRID_LVL</shortname>
+       <pname>CLMR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>125</post_avblfldidx>
+       <shortname>ICMR_ON_HYBRID_LVL</shortname>
+       <pname>ICMR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>126</post_avblfldidx>
+       <shortname>AVE_DSWRF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DSWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>127</post_avblfldidx>
+       <shortname>AVE_DLWRF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DLWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>128</post_avblfldidx>
+       <shortname>AVE_USWRF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>USWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>129</post_avblfldidx>
+       <shortname>AVE_ULWRF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ULWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>130</post_avblfldidx>
+       <shortname>AVE_USWRF_ON_TOP_OF_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>USWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>131</post_avblfldidx>
+       <shortname>AVE_ULWRF_ON_TOP_OF_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ULWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>132</post_avblfldidx>
+       <shortname>CD_ON_SURFACE</shortname>
+       <pname>CD</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>133</post_avblfldidx>
+       <shortname>UFLX_ON_SURFACE</shortname>
+       <pname>UFLX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>134</post_avblfldidx>
+       <shortname>VFLX_ON_SURFACE</shortname>
+       <pname>VFLX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>135</post_avblfldidx>
+       <shortname>AVE_GFLUX_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>GFLUX</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>136</post_avblfldidx>
+       <shortname>AVE_SNOHF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SNOHF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>137</post_avblfldidx>
+       <shortname>ACM_PEVAP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PEVAP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>138</post_avblfldidx>
+       <shortname>PRES_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>139</post_avblfldidx>
+       <shortname>AVE_CDLYR_ON_ENTIRE_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CDLYR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>140</post_avblfldidx>
+       <shortname>TTRAD_ON_HYBRID_LVL</shortname>
+       <pname>TTRAD</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>141</post_avblfldidx>
+       <shortname>INST_USWRF_ON_SURFACE</shortname>
+       <pname>USWRF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>142</post_avblfldidx>
+       <shortname>INST_ULWRF_ON_SURFACE</shortname>
+       <pname>ULWRF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>143</post_avblfldidx>
+       <shortname>AVE_CDCON_ON_ENTIRE_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CDCON</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>144</post_avblfldidx>
+       <shortname>AVE_TCDC_ON_ENTIRE_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>TCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>145</post_avblfldidx>
+       <shortname>TCDC_ON_HYBRID_LVL</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>146</post_avblfldidx>
+       <shortname>BMIXL_ON_HYBRID_LVL</shortname>
+       <pname>BMIXL</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>147</post_avblfldidx>
+       <shortname>AMIXL_ON_HYBRID_LVL</shortname>
+       <pname>AMIXL</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>148</post_avblfldidx>
+       <shortname>PRES_ON_CLOUD_BASE</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>149</post_avblfldidx>
+       <shortname>PRES_ON_CLOUD_TOP</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>150</post_avblfldidx>
+       <shortname>ALBDO_ON_SURFACE</shortname>
+       <pname>ALBDO</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>151</post_avblfldidx>
+       <shortname>WTMP_ON_SURFACE</shortname>
+       <pname>WTMP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>152</post_avblfldidx>
+       <shortname>INST_GFLUX_ON_SURFACE</shortname>
+       <pname>GFLUX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>153</post_avblfldidx>
+       <shortname>CLMR_ON_ISOBARIC_SFC</shortname>
+       <pname>CLMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>154</post_avblfldidx>
+       <shortname>INST_SHTFL_ON_SURFACE</shortname>
+       <pname>SHTFL</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>155</post_avblfldidx>
+       <shortname>INST_LHTFL_ON_SURFACE</shortname>
+       <pname>LHTFL</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>156</post_avblfldidx>
+       <shortname>INST_DSWRF_ON_SURFACE</shortname>
+       <pname>DSWRF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>157</post_avblfldidx>
+       <shortname>INST_DLWRF_ON_SURFACE</shortname>
+       <pname>DLWRF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>158</post_avblfldidx>
+       <shortname>POT_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>159</post_avblfldidx>
+       <shortname>SPFH_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>160</post_avblfldidx>
+       <shortname>INST_CRAIN_ON_SURFACE</shortname>
+       <pname>CRAIN</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>161</post_avblfldidx>
+       <shortname>INST_TCDC_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>162</post_avblfldidx>
+       <shortname>HLCY_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>HLCY</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>163</post_avblfldidx>
+       <shortname>USTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>USTM</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>164</post_avblfldidx>
+       <shortname>VSTM_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>VSTM</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>165</post_avblfldidx>
+       <shortname>HGT_ON_HGHST_TROP_FRZ_LVL</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>hghst_trop_frz_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>166</post_avblfldidx>
+       <shortname>ICMR_ON_ISOBARIC_SFC</shortname>
+       <pname>ICMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>167</post_avblfldidx>
+       <shortname>INST_PRATE_ON_SURFACE</shortname>
+       <pname>PRATE</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>168</post_avblfldidx>
+       <shortname>TMP_ON_CLOUD_TOP</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>169</post_avblfldidx>
+       <shortname>SFEXC_ON_SURFACE</shortname>
+       <pname>SFEXC</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>170</post_avblfldidx>
+       <shortname>VEG_ON_SURFACE</shortname>
+       <pname>VEG</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>171</post_avblfldidx>
+       <shortname>MSTAV_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>MSTAV</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>172</post_avblfldidx>
+       <shortname>CPOFP_ON_SURFACE</shortname>
+       <pname>CPOFP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>173</post_avblfldidx>
+       <shortname>PRES_ON_MAX_WIND</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>174</post_avblfldidx>
+       <shortname>HGT_ON_MAX_WIND</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>175</post_avblfldidx>
+       <shortname>UGRD_ON_MAX_WIND</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>176</post_avblfldidx>
+       <shortname>VGRD_ON_MAX_WIND</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>177</post_avblfldidx>
+       <shortname>HGT_ON_TROPOPAUSE</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>178</post_avblfldidx>
+       <shortname>HGT_ON_CLOUD_BASE</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>179</post_avblfldidx>
+       <shortname>HGT_ON_CLOUD_TOP</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>180</post_avblfldidx>
+       <shortname>VIS_ON_SURFACE</shortname>
+       <pname>VIS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>181</post_avblfldidx>
+       <shortname>RWMR_ON_HYBRID_LVL</shortname>
+       <pname>RWMR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>182</post_avblfldidx>
+       <shortname>SNMR_ON_HYBRID_LVL</shortname>
+       <pname>SNMR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>183</post_avblfldidx>
+       <shortname>RWMR_ON_ISOBARIC_SFC</shortname>
+       <pname>RWMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>184</post_avblfldidx>
+       <shortname>SNMR_ON_ISOBARIC_SFC</shortname>
+       <pname>SNMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>185</post_avblfldidx>
+       <shortname>FRAIN_ON_HYBRID_LVL</shortname>
+       <pname>FRAIN</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>186</post_avblfldidx>
+       <shortname>FICE_ON_HYBRID_LVL</shortname>
+       <pname>FICE</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>187</post_avblfldidx>
+       <shortname>RIME_ON_HYBRID_LVL</shortname>
+       <pname>RIME</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>188</post_avblfldidx>
+       <shortname>PRES_ON_CONVECTIVE_CLOUD_BOT_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>convective_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>189</post_avblfldidx>
+       <shortname>PRES_ON_CONVECTIVE_CLOUD_TOP_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>convective_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>190</post_avblfldidx>
+       <shortname>PRES_ON_SHALL_CONVECTIVE_CLOUD_BOT_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>shall_convective_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>191</post_avblfldidx>
+       <shortname>PRES_ON_SHALL_CONVECTIVE_CLOUD_TOP_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>shall_convective_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>192</post_avblfldidx>
+       <shortname>PRES_ON_DEEP_CONVECTIVE_CLOUD_BOT_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>deep_convective_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>193</post_avblfldidx>
+       <shortname>PRES_ON_DEEP_CONVECTIVE_CLOUD_TOP_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>deep_convective_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>194</post_avblfldidx>
+       <shortname>PRES_ON_GRID_SCALE_CLOUD_BOT_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>grid_scale_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>195</post_avblfldidx>
+       <shortname>PRES_ON_GRID_SCALE_CLOUD_TOP_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>grid_scale_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>196</post_avblfldidx>
+       <shortname>CDCON_ON_CONVECTIVE_CLOUD_LYR</shortname>
+       <pname>CDCON</pname>
+       <fixed_sfc1_type>convective_cloud_lyr</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>197</post_avblfldidx>
+       <shortname>CUEFI_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>CUEFI</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>198</post_avblfldidx>
+       <shortname>TCOND_ON_ISOBARIC_SFC</shortname>
+       <pname>TCOND</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>199</post_avblfldidx>
+       <shortname>TCOND_ON_HYBRID_LVL</shortname>
+       <pname>TCOND</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>200</post_avblfldidx>
+       <shortname>TCOLW_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLW</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>201</post_avblfldidx>
+       <shortname>TCOLI_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLI</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>202</post_avblfldidx>
+       <shortname>TCOLR_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLR</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>203</post_avblfldidx>
+       <shortname>TCOLS_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLS</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>204</post_avblfldidx>
+       <shortname>TCOLC_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLC</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>205</post_avblfldidx>
+       <shortname>HGT_ON_SIGMA_LVLS</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>206</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVLS</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>207</post_avblfldidx>
+       <shortname>SPFH_ON_SIGMA_LVLS</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>208</post_avblfldidx>
+       <shortname>UGRD_ON_SIGMA_LVLS</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>209</post_avblfldidx>
+       <shortname>VGRD_ON_SIGMA_LVLS</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>210</post_avblfldidx>
+       <shortname>VVEL_ON_SIGMA_LVLS</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>211</post_avblfldidx>
+       <shortname>CLMR_ON_SIGMA_LVLS</shortname>
+       <pname>CLMR</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>212</post_avblfldidx>
+       <shortname>ICMR_ON_SIGMA_LVLS</shortname>
+       <pname>ICMR</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>213</post_avblfldidx>
+       <shortname>RWMR_ON_SIGMA_LVLS</shortname>
+       <pname>RWMR</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>214</post_avblfldidx>
+       <shortname>SNMR_ON_SIGMA_LVLS</shortname>
+       <pname>SNMR</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>215</post_avblfldidx>
+       <shortname>TCOND_ON_SIGMA_LVLS</shortname>
+       <pname>TCOND</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>216</post_avblfldidx>
+       <shortname>PRES_ON_SIGMA_LVLS</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>217</post_avblfldidx>
+       <shortname>TKE_ON_SIGMA_LVLS</shortname>
+       <pname>TKE</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>218</post_avblfldidx>
+       <shortname>VGTYP_ON_SURFACE</shortname>
+       <pname>VGTYP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>219</post_avblfldidx>
+       <shortname>SOTYP_ON_SURFACE</shortname>
+       <pname>SOTYP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>220</post_avblfldidx>
+       <shortname>CCOND_ON_SURFACE</shortname>
+       <pname>CCOND</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>221</post_avblfldidx>
+       <shortname>HPBL_ON_SURFACE</shortname>
+       <pname>HPBL</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>222</post_avblfldidx>
+       <shortname>TCDC_ON_SIGMA_LVLS</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>223</post_avblfldidx>
+       <shortname>SLTYP_ON_SURFACE</shortname>
+       <pname>SLTYP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>224</post_avblfldidx>
+       <shortname>SNOD_ON_SURFACE</shortname>
+       <pname>SNOD</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>225</post_avblfldidx>
+       <shortname>SOILL_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>SOILL</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>226</post_avblfldidx>
+       <shortname>SNFALB_ON_SURFACE</shortname>
+       <pname>SNFALB</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>227</post_avblfldidx>
+       <shortname>MXSALB_ON_SURFACE</shortname>
+       <pname>MXSALB</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>228</post_avblfldidx>
+       <shortname>EVCW_ON_SURFACE</shortname>
+       <pname>EVCW</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>229</post_avblfldidx>
+       <shortname>EVBS_ON_SURFACE</shortname>
+       <pname>EVBS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>230</post_avblfldidx>
+       <shortname>TRANS_ON_SURFACE</shortname>
+       <pname>TRANS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>231</post_avblfldidx>
+       <shortname>SBSNO_ON_SURFACE</shortname>
+       <pname>SBSNO</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>232</post_avblfldidx>
+       <shortname>SMDRY_ON_SURFACE</shortname>
+       <pname>SMDRY</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>233</post_avblfldidx>
+       <shortname>POROS_ON_SURFACE</shortname>
+       <pname>POROS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>234</post_avblfldidx>
+       <shortname>RSMIN_ON_SURFACE</shortname>
+       <pname>RSMIN</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>235</post_avblfldidx>
+       <shortname>RLYRS_ON_SURFACE</shortname>
+       <pname>RLYRS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>236</post_avblfldidx>
+       <shortname>WILT_ON_SURFACE</shortname>
+       <pname>WILT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>237</post_avblfldidx>
+       <shortname>SMREF_ON_SURFACE</shortname>
+       <pname>SMREF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>238</post_avblfldidx>
+       <shortname>RCS_ON_SURFACE</shortname>
+       <pname>RCS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>239</post_avblfldidx>
+       <shortname>RCT_ON_SURFACE</shortname>
+       <pname>RCT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>240</post_avblfldidx>
+       <shortname>RCQ_ON_SURFACE</shortname>
+       <pname>RCQ</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>241</post_avblfldidx>
+       <shortname>RCSOL_ON_SURFACE</shortname>
+       <pname>RCSOL</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>242</post_avblfldidx>
+       <shortname>PEVPR_ON_SURFACE</shortname>
+       <pname>PEVPR</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>243</post_avblfldidx>
+       <shortname>VEDH_ON_SIGMA_LVLS</shortname>
+       <pname>VEDH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>245</post_avblfldidx>
+       <shortname>GUST_ON_SURFACE</shortname>
+       <pname>GUST</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>246</post_avblfldidx>
+       <shortname>PLPL_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>PLPL</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>247</post_avblfldidx>
+       <shortname>HGT_ON_LWST_LVL_OF_WET_BULB_ZERO</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>lwst_lvl_of_wet_bulb_zero</fixed_sfc1_type>
+       <scale>-5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>249</post_avblfldidx>
+       <shortname>CPRAT_ON_SURFACE</shortname>
+       <pname>CPRAT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>250</post_avblfldidx>
+       <shortname>REFD_ON_HYBRID_LVL</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>251</post_avblfldidx>
+       <shortname>REFD_ON_ISOBARIC_SFC</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>252</post_avblfldidx>
+       <shortname>REFC_ON_ENTIRE_ATMOS</shortname>
+       <pname>REFC</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>253</post_avblfldidx>
+       <shortname>REFD_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>254</post_avblfldidx>
+       <shortname>LAI_ON_SURFACE</shortname>
+       <pname>LAI</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>255</post_avblfldidx>
+       <shortname>GRLE_ON_SIGMA_LVLS</shortname>
+       <pname>GRLE</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>256</post_avblfldidx>
+       <shortname>ACM_LSPA_ON_SURFACE</shortname>
+	   <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>LSPA</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>257</post_avblfldidx>
+       <shortname>TIPD_ON_ISOBARIC_SFC</shortname>
+       <pname>TIPD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>258</post_avblfldidx>
+       <shortname>TPFI_ON_ISOBARIC_SFC</shortname>
+       <pname>TPFI</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>259</post_avblfldidx>
+       <shortname>VWSH_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>VWSH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>260</post_avblfldidx>
+       <shortname>HGT_ON_CLOUD_CEILING</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>cloud_ceilng</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>261</post_avblfldidx>
+       <shortname>VIS_ON_CLOUD_BASE</shortname>
+       <pname>VIS</pname>
+       <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>262</post_avblfldidx>
+       <shortname>INST_CSDSF_ON_SURFACE</shortname>
+       <pname>CSDSF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>263</post_avblfldidx>
+       <shortname>RIME_ON_ISOBARIC_SFC</shortname>
+       <pname>RIME</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>264</post_avblfldidx>
+       <shortname>DZDT_ON_HYBRID_LVL</shortname>
+       <pname>DZDT</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>-5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>265</post_avblfldidx>
+       <shortname>SBT122_ON_TOP_OF_ATMOS_FROM_LWRAD</shortname>
+       <pname>SBT122</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>266</post_avblfldidx>
+       <shortname>AVE_ALBDO_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ALBDO</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>267</post_avblfldidx>
+       <shortname>O3MR_ON_HYBRID_LVL</shortname>
+       <pname>O3MR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>7.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>268</post_avblfldidx>
+       <shortname>O3MR_ON_ISOBARIC_SFC</shortname>
+       <pname>O3MR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>269</post_avblfldidx>
+       <shortname>AVE_UFLX_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>UFLX</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>270</post_avblfldidx>
+       <shortname>AVE_VFLX_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>VFLX</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>271</post_avblfldidx>
+       <shortname>AVE_PRATE_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PRATE</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>272</post_avblfldidx>
+       <shortname>AVE_CPRAT_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CPRAT</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>273</post_avblfldidx>
+       <shortname>PRES_ON_HYBRID_LVL_LLM</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <fixed_sfc2_type>hybrid_lvl</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>274</post_avblfldidx>
+       <shortname>INST_ULWRF_ON_TOP_OF_ATMOS</shortname>
+       <pname>ULWRF</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>275</post_avblfldidx>
+       <shortname>BRTMP_ON_TOP_OF_ATMOS</shortname>
+       <pname>BRTMP</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>276</post_avblfldidx>
+       <shortname>REFZR_ON_ENTIRE_ATMOS</shortname>
+       <pname>REFZR</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>277</post_avblfldidx>
+       <shortname>REFZI_ON_ENTIRE_ATMOS</shortname>
+       <pname>REFZI</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>278</post_avblfldidx>
+       <shortname>REFZC_ON_ENTIRE_ATMOS</shortname>
+       <pname>REFZC</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>279</post_avblfldidx>
+       <shortname>REFZR_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>REFZR</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>280</post_avblfldidx>
+       <shortname>REFZI_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>REFZI</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>281</post_avblfldidx>
+       <shortname>REFZC_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>REFZC</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>282</post_avblfldidx>
+       <shortname>PRES_ON_TOP_OF_ATMOS</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+
+    <param>
+       <post_avblfldidx>283</post_avblfldidx>
+       <shortname>PRES_ON_HYBRID_LVL_1L</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <fixed_sfc2_type>hybrid_lvl</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>284</post_avblfldidx>
+       <shortname>DZDT_ON_ISOBARIC_SFC</shortname>
+       <pname>DZDT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>-5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>285</post_avblfldidx>
+       <shortname>TCLSW_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCLSW</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>286</post_avblfldidx>
+       <shortname>TCOLM_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLM</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>287</post_avblfldidx>
+       <shortname>HGT_ON_LWST_BOT_LVL_OF_SUPERCOOLED_LIQ_WATER_LYR</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>lwst_bot_lvl_of_supercooled_liq_water_lyr</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>288</post_avblfldidx>
+       <shortname>HGT_ON_HGHST_TOP_LVL_OF_SUPERCOOLED_LIQ_WATER_LYR</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>hghst_top_lvl_of_supercooled_liq_water_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>289</post_avblfldidx>
+       <shortname>HGT_ON_PLANETARY_BOUND_LYR</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>planetary_bound_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>290</post_avblfldidx>
+       <shortname>SWHR_ON_ENTIRE_ATMOS</shortname>
+       <pname>SWHR</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>291</post_avblfldidx>
+       <shortname>LWHR_ON_ENTIRE_ATMOS</shortname>
+       <pname>LWHR</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>292</post_avblfldidx>
+       <shortname>AVE_LRGHR_ON_ENTIRE_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>LRGHR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>293</post_avblfldidx>
+       <shortname>AVE_CNVHR_ON_ENTIRE_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CNVHR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>294</post_avblfldidx>
+       <shortname>TTRAD_ON_ISOBARIC_SFC</shortname>
+       <pname>TTRAD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>295</post_avblfldidx>
+       <shortname>MCONV_ON_ENTIRE_ATMOS</shortname>
+       <pname>MCONV</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>296</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVL_HPC</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>297</post_avblfldidx>
+       <shortname>AVE_CDUVB_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CDUVB</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>298</post_avblfldidx>
+       <shortname>AVE_DUVB_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DUVB</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>299</post_avblfldidx>
+       <shortname>TOZNE_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>TOZNE</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>300</post_avblfldidx>
+       <shortname>AVE_TCDC_ON_LOW_CLOUD_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>LCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>low_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>301</post_avblfldidx>
+       <shortname>AVE_TCDC_ON_MID_CLOUD_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>mid_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>302</post_avblfldidx>
+       <shortname>AVE_TCDC_ON_HIGH_CLOUD_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>HCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>high_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>303</post_avblfldidx>
+       <shortname>AVE_PRES_ON_LOW_CLOUD_BOT_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>low_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>304</post_avblfldidx>
+       <shortname>AVE_PRES_ON_LOW_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>low_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>305</post_avblfldidx>
+       <shortname>AVE_TMP_ON_LOW_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>low_cloud_top_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>306</post_avblfldidx>
+       <shortname>AVE_PRES_ON_MID_CLOUD_BOT_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>mid_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>307</post_avblfldidx>
+       <shortname>AVE_PRES_ON_MID_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>mid_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>308</post_avblfldidx>
+       <shortname>AVE_TMP_ON_MID_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>mid_cloud_top_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>309</post_avblfldidx>
+       <shortname>AVE_PRES_ON_HIGH_CLOUD_BOT_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>high_cloud_bot_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>310</post_avblfldidx>
+       <shortname>AVE_PRES_ON_HIGH_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>high_cloud_top_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>311</post_avblfldidx>
+       <shortname>AVE_TMP_ON_HIGH_CLOUD_TOP_LVL</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>high_cloud_top_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>312</post_avblfldidx>
+       <shortname>RH_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>313</post_avblfldidx>
+       <shortname>AVE_CWORK_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CWORK</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>314</post_avblfldidx>
+       <shortname>TMP_ON_MAX_WIND</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>315</post_avblfldidx>
+       <shortname>AVE_U-GWD_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>U-GWD</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>316</post_avblfldidx>
+       <shortname>AVE_V-GWD_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>V-GWD</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>317</post_avblfldidx>
+       <shortname>AVE_CRAIN_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CRAIN</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>318</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.44-1.0</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>44.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>100.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>319</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.72-0.94</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>72.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>94.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>320</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.44-0.72</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>44.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>72.</level2>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>321</post_avblfldidx>
+       <shortname>TMP_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>322</post_avblfldidx>
+       <shortname>POT_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>323</post_avblfldidx>
+       <shortname>RH_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>324</post_avblfldidx>
+       <shortname>UGRD_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>325</post_avblfldidx>
+       <shortname>VGRD_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>326</post_avblfldidx>
+       <shortname>VVEL_ON_SIGMA_LVL_0.9950</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>4</scale_fact_fixed_sfc1>
+       <level>9950.</level>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>327</post_avblfldidx>
+       <shortname>SBT122_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT122</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>328</post_avblfldidx>
+       <shortname>SBT123_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT123</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>329</post_avblfldidx>
+       <shortname>SBT124_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT124</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>330</post_avblfldidx>
+       <shortname>SBT126_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT126</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>331</post_avblfldidx>
+       <shortname>TCDC_ON_ISOBARIC_SFC</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>332</post_avblfldidx>
+       <shortname>UGRD_ON_ISENTROPIC_LVL</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>333</post_avblfldidx>
+       <shortname>VGRD_ON_ISENTROPIC_LVL</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>334</post_avblfldidx>
+       <shortname>TMP_ON_ISENTROPIC_LVL</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>335</post_avblfldidx>
+       <shortname>PVORT_ON_ISENTROPIC_LVL</shortname>
+       <pname>PVORT</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>336</post_avblfldidx>
+       <shortname>UGRD_ON_POT_VORT_SFC</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>337</post_avblfldidx>
+       <shortname>VGRD_ON_POT_VORT_SFC</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>338</post_avblfldidx>
+       <shortname>TMP_ON_POT_VORT_SFC</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>339</post_avblfldidx>
+       <shortname>HGT_ON_POT_VORT_SFC</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>340</post_avblfldidx>
+       <shortname>PRES_ON_POT_VORT_SFC</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>341</post_avblfldidx>
+       <shortname>VWSH_ON_POT_VORT_SFC</shortname>
+       <pname>VWSH</pname>
+       <fixed_sfc1_type>pot_vort_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>342</post_avblfldidx>
+       <shortname>AVE_TCDC_ON_BOUND_LYR_CLOUD_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>TCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>bound_lyr_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>343</post_avblfldidx>
+       <shortname>ACM_WATR_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>WATR</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>344</post_avblfldidx>
+       <shortname>PBLREG_ON_SURFACE</shortname>
+       <pname>PBLREG</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>345</post_avblfldidx>
+       <shortname>MAX_TMAX_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMAX</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>346</post_avblfldidx>
+       <shortname>MIN_TMIN_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMIN</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>347</post_avblfldidx>
+       <shortname>MAX_MAXRH_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MAXRH</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>-2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>348</post_avblfldidx>
+       <shortname>MIN_MINRH_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MINRH</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>-2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>349</post_avblfldidx>
+       <shortname>ICETK_ON_SURFACE</shortname>
+       <pname>ICETK</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>350</post_avblfldidx>
+       <shortname>RH_ON_HGHST_TROP_FRZ_LVL</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>hghst_trop_frz_lvl</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+<!--- 351-352 -->
+    <param>
+       <post_avblfldidx>351</post_avblfldidx>
+       <shortname>LAPR_ON_ISENTROPIC_LVL</shortname>
+       <pname>LAPR</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>352</post_avblfldidx>
+       <shortname>RH_ON_ISENTROPIC_LVL</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>353</post_avblfldidx>
+       <shortname>MNTSF_ON_ISENTROPIC_LVL</shortname>
+       <pname>MNTSF</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+<!---354 to 356 -->
+    <param>
+       <post_avblfldidx>354</post_avblfldidx>
+       <shortname>SWHR_ON_ISOBARIC_SFC</shortname>
+       <pname>SWHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>355</post_avblfldidx>
+       <shortname>LWHR_ON_ISOBARIC_SFC</shortname>
+       <pname>LWHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>356</post_avblfldidx>
+       <shortname>VDFHR_ON_ISOBARIC_SFC</shortname>
+       <pname>VDFHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>357</post_avblfldidx>
+       <shortname>CNVHR_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>2.7</scale>
+    </param>
+
+<!---358-375 -->
+    <param>
+       <post_avblfldidx>358</post_avblfldidx>
+       <shortname>SHAHR_ON_ISOBARIC_SFC</shortname>
+       <pname>SHAHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>359</post_avblfldidx>
+       <shortname>LRGHR_ON_ISOBARIC_SFC</shortname>
+       <pname>LRGHR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>360</post_avblfldidx>
+       <shortname>VDFMR_ON_ISOBARIC_SFC</shortname>
+       <pname>VDFMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>361</post_avblfldidx>
+       <shortname>CNVMR_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>362</post_avblfldidx>
+       <shortname>SHAMR_ON_ISOBARIC_SFC</shortname>
+       <pname>SHAMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>363</post_avblfldidx>
+       <shortname>LRGMR_ON_ISOBARIC_SFC</shortname>
+       <pname>LRGMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>364</post_avblfldidx>
+       <shortname>VDFOZ_ON_ISOBARIC_SFC</shortname>
+       <pname>VDFOZ</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>7.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>365</post_avblfldidx>
+       <shortname>POZ_ON_ISOBARIC_SFC</shortname>
+       <pname>POZ</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>366</post_avblfldidx>
+       <shortname>TOZ_ON_ISOBARIC_SFC</shortname>
+       <pname>TOZ</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>367</post_avblfldidx>
+       <shortname>PVMW_ON_ISOBARIC_SFC</shortname>
+       <pname>PVMW</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>368</post_avblfldidx>
+       <shortname>SNOT_ON_ISOBARIC_SFC</shortname>
+       <pname>SNOT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>369</post_avblfldidx>
+       <shortname>VDFUA_ON_ISOBARIC_SFC</shortname>
+       <pname>VDFUA</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>370</post_avblfldidx>
+       <shortname>GWDU_ON_ISOBARIC_SFC</shortname>
+       <pname>GWDU</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>371</post_avblfldidx>
+       <shortname>CNVU_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVU</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>372</post_avblfldidx>
+       <shortname>VDFVA_ON_ISOBARIC_SFC</shortname>
+       <pname>VDFVA</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>373</post_avblfldidx>
+       <shortname>GWDV_ON_ISOBARIC_SFC</shortname>
+       <pname>GWDV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>374</post_avblfldidx>
+       <shortname>CNVV_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>375</post_avblfldidx>
+       <shortname>CDLYR_ON_ISOBARIC_SFC</shortname>
+       <pname>CDLYR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>376</post_avblfldidx>
+       <shortname>SBC123_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBC123</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>377</post_avblfldidx>
+       <shortname>SBC124_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBC124</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>378</post_avblfldidx>
+       <shortname>VVEL_ON_ISENTROPIC_LVL</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>isentropic_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <!-- D3D fields -->
+
+<!--379- 380  -->
+    <param>
+       <post_avblfldidx>379</post_avblfldidx>
+       <shortname>TTDIA_ON_ISOBARIC_SFC</shortname>
+       <pname>TTDIA</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>380</post_avblfldidx>
+       <shortname>VEDH_ON_HYBRID_LVL</shortname>
+       <pname>VEDH</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>381</post_avblfldidx>
+       <shortname>MIXHT_ON_SURFACE</shortname>
+       <pname>MIXHT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+<!--382- 387  -->
+    <param>
+       <post_avblfldidx>382</post_avblfldidx>
+       <shortname>AVE_CSDLF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSDLF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>383</post_avblfldidx>
+       <shortname>AVE_CSDSF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSDSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>384</post_avblfldidx>
+       <shortname>AVE_CSULF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSULF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>385</post_avblfldidx>
+       <shortname>AVE_CSULF_ON_TOP_OF_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSULF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>386</post_avblfldidx>
+       <shortname>AVE_CSUSF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSUSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>387</post_avblfldidx>
+       <shortname>AVE_CSUSF_ON_TOP_OF_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>CSUSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>388</post_avblfldidx>
+       <shortname>AVE_DSWRF_ON_TOP_OF_ATMOS</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DSWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>389</post_avblfldidx>
+       <shortname>UGRD_ON_PLANETARY_BOUND_LYR</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>planetary_bound_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>390</post_avblfldidx>
+       <shortname>VGRD_ON_PLANETARY_BOUND_LYR</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>planetary_bound_lyr</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+<!--391-395 -->
+    <param>
+       <post_avblfldidx>391</post_avblfldidx>
+       <shortname>CNVUMF_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVUMF</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>392</post_avblfldidx>
+       <shortname>CNVDMF_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVDMF</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>393</post_avblfldidx>
+       <shortname>CNVEMF_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVEMF</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>394</post_avblfldidx>
+       <shortname>CNVWDU_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVWDU</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>395</post_avblfldidx>
+       <shortname>CNVWDV_ON_ISOBARIC_SFC</shortname>
+       <pname>CNVWDV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+   <!-- TIGGE filds -->
+    <param>
+       <post_avblfldidx>396</post_avblfldidx>
+       <shortname>SUNSD_ON_SURFACE</shortname>
+       <pname>SUNSD</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>397</post_avblfldidx>
+       <shortname>FLDCP_ON_SURFACE</shortname>
+       <pname>FLDCP</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+   <!-- ICAO filds -->
+    <param>
+       <post_avblfldidx>398</post_avblfldidx>
+       <shortname>ICAHT_ON_MAX_WIND</shortname>
+       <pname>ICAHT</pname>
+       <fixed_sfc1_type>max_wind</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>399</post_avblfldidx>
+       <shortname>ICAHT_ON_TROPOPAUSE</shortname>
+       <pname>ICAHT</pname>
+       <fixed_sfc1_type>tropopause</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>400</post_avblfldidx>
+       <shortname>RETOP_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>RETOP</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>-6.0</scale>
+    </param>
+
+   <!-- more CFSRR filds -->
+<!--- 401-405 -->
+    <param>
+       <post_avblfldidx>401</post_avblfldidx>
+       <shortname>AVE_VBDSF_ON_SURFACE</shortname>
+       <longname>averaged surface visible beam downward solar flux</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>VBDSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>402</post_avblfldidx>
+       <shortname>AVE_VDDSF_ON_SURFACE</shortname>
+       <longname>averaged surface visible diffuse downward solar flux</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>VDDSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>403</post_avblfldidx>
+       <shortname>AVE_NBDSF_ON_SURFACE</shortname>
+       <longname>averaged surface near IR beam downward solar flux</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NBDSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>404</post_avblfldidx>
+       <shortname>AVE_NDDSF_ON_SURFACE</shortname>
+       <longname>averaged surface near IR beam downward solar flux</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NDDSF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>405</post_avblfldidx>
+       <shortname>AVE_SRWEQ_ON_SURFACE</shortname>
+       <longname>averaged snow rate on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SRWEQ</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>406</post_avblfldidx>
+       <shortname>GSD_PRES_ON_CLOUD_TOP</shortname>
+       <longname>GSD_pressure on cloud top</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>407</post_avblfldidx>
+       <shortname>GSD_INST_CRAIN_ON_SURFACE</shortname>
+       <longname>GSD_instant precipitation type on surface</longname>
+       <pname>CRAIN</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>408</post_avblfldidx>
+       <shortname>GSD_HGT_ON_CLOUD_CEILING</shortname>
+       <longname>GSD_geopotential height on cloud ceiling</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>cloud_ceilng</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>409</post_avblfldidx>
+       <shortname>GSD_HGT_ON_CLOUD_TOP</shortname>
+       <longname>GSD_geopotential height on cloud top</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>410</post_avblfldidx>
+       <shortname>GSD_VIS_ON_SURFACE</shortname>
+       <longname>GSD_visibility on surface</longname>
+       <pname>VIS</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+<!--411 -->
+    <param>
+       <post_avblfldidx>411</post_avblfldidx>
+       <shortname>WMIXE_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <longname>instant wind mixing energy on Specified Height Level Above Ground</longname>
+       <pname>WMIXE</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>412</post_avblfldidx>
+       <shortname>UGRD_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <longname>U-Component of Wind on Specified Height Level Above Ground</longname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>413</post_avblfldidx>
+       <shortname>VGRD_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <longname>V-Component of Wind on Specified Height Level Above Ground</longname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+<!-- 415 -->
+    <param>
+       <post_avblfldidx>415</post_avblfldidx>
+       <shortname>GRLE_ON_HYBRID_LVL</shortname>
+       <longname>Graupel mixing ration on hybrid level</longname>
+       <pname>GRLE</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>416</post_avblfldidx>
+       <shortname>GRLE_ON_ISOBARIC_SFC</shortname>
+       <longname>Graupel mixing ration on isobaric surface</longname>
+       <pname>GRLE</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>417</post_avblfldidx>
+       <shortname>CACM_APCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>APCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>418</post_avblfldidx>
+       <shortname>CACM_ACPCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ACPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>419</post_avblfldidx>
+       <shortname>CACM_NCPCP_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NCPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>420</post_avblfldidx>
+       <shortname>MAX_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_2-5km</shortname>
+       <longname>maximum Updraft Helicity on Specified Height Level Above Ground</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MXUPHL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>5000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>2000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>421</post_avblfldidx>
+       <shortname>MAX_REF_ON_SPEC_HGT_LVL_ABOVE_GRND_1km</shortname>
+       <longname>maximum Updraft Helicity on Specified Height Level Above Ground</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MAXREF</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>1000.</level>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>422</post_avblfldidx>
+       <shortname>MAX_WIND_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <longname>maximum wind speed on 10 meter Above Ground</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>WIND</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>423</post_avblfldidx>
+       <shortname>MAX_MAXUVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
+       <longname>hourly maximum Upward Vertical Velocity between 100-1000hpa</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MAXUVV</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>10000.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>100000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>424</post_avblfldidx>
+       <shortname>MAX_MAXDVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa</shortname>
+       <longname>hourly maximum Downward Vertical Velocity between 100-1000hpa</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MAXDVV</pname>
+       <stats_proc>MAX</stats_proc>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>10000.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>100000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+<!--425-426 -->
+    <param>
+       <post_avblfldidx>425</post_avblfldidx>
+       <shortname>AVE_DZDT_ON_SIGMA_LVL_0.5-0.8</shortname>
+       <longname>average Vertical velocity between sigma lvl 0.5 and 0.8</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DZDT</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>2</scale_fact_fixed_sfc1>
+       <level>50.</level>
+       <fixed_sfc2_type>sigma_lvl</fixed_sfc2_type>
+       <scale_fact_fixed_sfc2>2</scale_fact_fixed_sfc2>
+       <level2>80.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>426</post_avblfldidx>
+       <shortname>HGT_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <longname>Echo Tops in KFT (highest HGTin meters of the 18-dBZ reflectivity on a model level)</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>427</post_avblfldidx>
+       <shortname>UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_2-5km</shortname>
+       <longname>Updraft Helicity on Specified Height Level Above Ground</longname>
+       <pname>UPHL</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>5000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>2000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+<!-- 428-433-->
+    <param>
+       <post_avblfldidx>428</post_avblfldidx>
+       <shortname>TCOLG_ON_ENTIRE_ATMOS</shortname>
+       <pname>TCOLG</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>429</post_avblfldidx>
+       <shortname>MAXVIG_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <longname>Hourly Maximum of Column Vertical Integrated Graupel on entire atmosphere</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MAXVIG</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>430</post_avblfldidx>
+       <shortname>VUCSH_ON_SPEC_HGT_LVL_ABOVE_GRND_0-1km</shortname>
+       <longname>Vertical u-component shear between 0 to 1000m Above Ground</longname>
+       <pname>VUCSH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>1000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>431</post_avblfldidx>
+       <shortname>VVCSH_ON_SPEC_HGT_LVL_ABOVE_GRND_0-1km</shortname>
+       <longname>Vertical v-component shear between 0 to 1000m Above Ground</longname>
+       <pname>VVCSH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>1000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>432</post_avblfldidx>
+       <shortname>VUCSH_ON_SPEC_HGT_LVL_ABOVE_GRND_0-6km</shortname>
+       <longname>Vertical u-component shear between 0 to 6000m Above Ground</longname>
+       <pname>VUCSH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>6000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>433</post_avblfldidx>
+       <shortname>VVCSH_ON_SPEC_HGT_LVL_ABOVE_GRND_0-6km</shortname>
+       <longname>Vertical v-component shear between 0 to 6000m Above Ground</longname>
+       <pname>VVCSH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>6000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+<!--434-437 -->
+    <param>
+       <post_avblfldidx>434</post_avblfldidx>
+       <shortname>BUCKET_APCP_ON_SURFACE</shortname>
+       <longname>bucket Total precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>APCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>435</post_avblfldidx>
+       <shortname>BUCKET_ACPCP_ON_SURFACE</shortname>
+       <longname>bucket Convective precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>ACPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>436</post_avblfldidx>
+       <shortname>BUCKET_NCPCP_ON_SURFACE</shortname>
+       <longname>bucket Large scale precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NCPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>437</post_avblfldidx>
+       <shortname>BUCKET_WEASD_ON_SURFACE</shortname>
+       <longname>bucket snow precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>WEASD</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <!-- dust fields on P sfc-->
+
+    <param>
+       <post_avblfldidx>438</post_avblfldidx>
+       <shortname>DUST1_ON_ISOBARIC_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>isobaric_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>2</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>20</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>439</post_avblfldidx>
+       <shortname>DUST2_ON_ISOBARIC_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>isobaric_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>36</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>440</post_avblfldidx>
+       <shortname>DUST3_ON_ISOBARIC_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>isobaric_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>36</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>60</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>441</post_avblfldidx>
+       <shortname>DUST4_ON_ISOBARIC_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>isobaric_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>60</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>120</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>442</post_avblfldidx>
+       <shortname>DUST5_ON_ISOBARIC_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>isobaric_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>120</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>200</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+
+<!--443-->
+    <param>
+       <post_avblfldidx>443</post_avblfldidx>
+       <shortname>HGT_ON_EQUIL_LVL</shortname>
+       <longname>geopotential height on Equilibrium level</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>equil_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>444</post_avblfldidx>
+       <shortname>LTNG_ON_SURFACE</shortname>
+       <longname>lightning</longname>
+       <pname>LTNG</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+<!-- 445-->
+    <param>
+       <post_avblfldidx>445</post_avblfldidx>
+       <shortname>MAPS_PRMSL_ON_MEAN_SEA_LVL</shortname>
+       <pname>PRMSL</pname>
+       <fixed_sfc1_type>mean_sea_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>446</post_avblfldidx>
+       <shortname>SBT112_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT112</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>447</post_avblfldidx>
+       <shortname>SBT113_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT113</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>448</post_avblfldidx>
+       <shortname>SBT114_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT114</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>449</post_avblfldidx>
+       <shortname>SBT115_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBT115</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+<!-- 450-451 -->
+    <param>
+       <post_avblfldidx>450</post_avblfldidx>
+       <shortname>ICIP_ON_ICAO_STD_SFC</shortname>
+       <longname>Total Icing Potential Diagnostic on standard atmospheric isobaric sfc</longname>
+       <pname>ICIP</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>451</post_avblfldidx>
+       <shortname>SPFH_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>452</post_avblfldidx>
+       <shortname>VTCAPE_ON_SURFACE</shortname>
+       <longname>Virtual Temperature Based Convective Available Potential Energy on surface</longname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>453</post_avblfldidx>
+       <shortname>VTCIN_ON_SURFACE</shortname>
+       <longname>Virtual Temperature Based Convective Inhibition on surface</longname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+<!-- 454-455 -->
+    <param>
+       <post_avblfldidx>454</post_avblfldidx>
+       <shortname>VRATE_ON_PLANETARY_BOUND_LYR</shortname>
+       <longname>Ventilation Rate on planetary boundary layer</longname>
+       <pname>VRATE</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>planetary_bound_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>455</post_avblfldidx>
+       <shortname>HINDEX_ON_SURFACE</shortname>
+       <longname>Haines Index on surface</longname>
+       <pname>HINDEX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>456</post_avblfldidx>
+       <shortname>NON_NADIR_SBT122_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES12, Channel 2 on top of atmosphere</longname>
+       <pname>SBT122</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>457</post_avblfldidx>
+       <shortname>NON_NADIR_SBT123_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES12, Channel 3 on top of atmosphere</longname>
+       <pname>SBT123</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>458</post_avblfldidx>
+       <shortname>NON_NADIR_SBT124_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES12, Channel 4 on top of atmosphere</longname>
+       <pname>SBT124</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>459</post_avblfldidx>
+       <shortname>NON_NADIR_SBT126_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES12, Channel 6 on top of atmosphere</longname>
+       <pname>SBT126</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>460</post_avblfldidx>
+       <shortname>SBT112_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES11, Channel 2 on top of atmosphere</longname>
+       <pname>SBT112</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>461</post_avblfldidx>
+       <shortname>SBT113_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES11, Channel 3 on top of atmosphere</longname>
+       <pname>SBT113</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>462</post_avblfldidx>
+       <shortname>SBT114_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES11, Channel 4 on top of atmosphere</longname>
+       <pname>SBT114</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>463</post_avblfldidx>
+       <shortname>SBT115_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for GOES11, Channel 5 on top of atmosphere</longname>
+       <pname>SBT115</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+<!-- 464-466 EDR on STD ISOBARIC_SFC -->
+    <param>
+       <post_avblfldidx>464</post_avblfldidx>
+       <shortname>EDPARM_GTG_ON_ICAO_STD_SFC</shortname>
+       <pname>EDPARM</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>465</post_avblfldidx>
+       <shortname>CAT_GTG_ON_ICAO_STD_SFC</shortname>
+       <pname>CATEDR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>466</post_avblfldidx>
+       <shortname>MWTURB_GTG_ON_ICAO_STD_SFC</shortname>
+       <pname>MWTURB</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+<!-- 467-469 EDR on FD_HEIGHT_LVL -->
+    <param>
+       <post_avblfldidx>467</post_avblfldidx>
+       <shortname>EDPARM_GTG_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>EDPARM</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>468</post_avblfldidx>
+       <shortname>CAT_GTG_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>CATEDR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>469</post_avblfldidx>
+       <shortname>MWTURB_GTG_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>MWTURB</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+<!-- 470-472 EDR on hybrid level -->
+    <param>
+       <post_avblfldidx>470</post_avblfldidx>
+       <shortname>EDPARM_ON_HYBRID_LVL</shortname>
+       <pname>EDPARM</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>471</post_avblfldidx>
+       <shortname>CAT_ON_HYBRID_LVL</shortname>
+       <pname>CATEDR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>472</post_avblfldidx>
+       <shortname>MWTURB_ON_HYBRID_LVL</shortname>
+       <pname>MWTURB</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+<!-- 473-475 for CB cover, base, and top -->
+    <param>
+       <post_avblfldidx>473</post_avblfldidx>
+       <shortname>CBHE_ON_ENTIRE_ATMOS</shortname>
+       <pname>CBHE</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>474</post_avblfldidx>
+       <shortname>ICAHT_ON_CB_BASE</shortname>
+       <pname>ICAHT</pname>
+       <fixed_sfc1_type>cb_base</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>475</post_avblfldidx>
+       <shortname>ICAHT_ON_CB_TOP</shortname>
+       <pname>ICAHT</pname>
+       <fixed_sfc1_type>cb_top</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>480</post_avblfldidx>
+       <shortname>ICESEV_ON_ICAO_STD_SFC</shortname>
+       <longname>Icing severity on standard atmospheric isobaric levels</longname>
+       <pname>ICESEV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>482</post_avblfldidx>
+       <shortname>PRES_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <longname>pressure between Specific Altitude Above Mean Sea Level</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <fixed_sfc2_type>spec_alt_above_mean_sea_lvl</fixed_sfc2_type>
+       <scale>3.0</scale>
+    </param>
+
+<!-- 483-486, 487-499 -->
+    <param>
+       <post_avblfldidx>483</post_avblfldidx>
+       <shortname>AMSRE9_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for AMSRE on Aqua, Channel 9 on top of atmosphere</longname>
+       <pname>AMSRE9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>484</post_avblfldidx>
+       <shortname>AMSRE10_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for AMSRE on Aqua, Channel 10 on top of atmosphere</longname>
+       <pname>AMSRE10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>485</post_avblfldidx>
+       <shortname>AMSRE11_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for AMSRE on Aqua, Channel 11 on top of atmosphere</longname>
+       <pname>AMSRE11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>486</post_avblfldidx>
+       <shortname>AMSRE12_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for AMSRE on Aqua, Channel 12 on top of atmosphere</longname>
+       <pname>AMSRE12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>487</post_avblfldidx>
+       <shortname>GSD_EXP_CEILING</shortname>
+       <pname>CEIL</pname>
+       <fixed_sfc1_type>cloud_ceilng</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>488</post_avblfldidx>
+       <shortname>TMITB6_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for TMI TRMM, Channel 6 on top of atmosphere</longname>
+       <pname>AMSRE9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>489</post_avblfldidx>
+       <shortname>TMITB7_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for TMI TRMM, Channel 7 on top of atmosphere</longname>
+       <pname>AMSRE10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>490</post_avblfldidx>
+       <shortname>TMITB8_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for TMI TRMM, Channel 8 on top of atmosphere</longname>
+       <pname>AMSRE11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>491</post_avblfldidx>
+       <shortname>TMITB9_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for TMI TRMM, Channel 9 on top of atmosphere</longname>
+       <pname>AMSRE12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>492</post_avblfldidx>
+       <shortname>SSMITB4_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMI TB, Channel 4 on top of atmosphere</longname>
+       <pname>AMSRE9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>493</post_avblfldidx>
+       <shortname>SSMITB5_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMI TB, Channel 5 on top of atmosphere</longname>
+       <pname>AMSRE10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>494</post_avblfldidx>
+       <shortname>SSMITB6_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMI TB, Channel 6 on top of atmosphere</longname>
+       <pname>AMSRE11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>495</post_avblfldidx>
+       <shortname>SSMITB7_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMI TB, Channel 7 on top of atmosphere</longname>
+       <pname>AMSRE12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>496</post_avblfldidx>
+       <shortname>SSMISTB15_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMIS TB, Channel 15 on top of atmosphere</longname>
+       <pname>AMSRE9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>497</post_avblfldidx>
+       <shortname>SSMISTB16_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMIS TB, Channel 16 on top of atmosphere</longname>
+       <pname>AMSRE10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>498</post_avblfldidx>
+       <shortname>SSMISTB17_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMIS TB, Channel 17 on top of atmosphere</longname>
+       <pname>AMSRE11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>499</post_avblfldidx>
+       <shortname>SSMISTB18_ON_TOP_OF_ATMOS</shortname>
+       <longname>Simulated Brightness Temperature for SSMIS TB, Channel 18 on top of atmosphere</longname>
+       <pname>AMSRE12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>500</post_avblfldidx>
+       <shortname>AVE_SNOWC_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>SNOWC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>501</post_avblfldidx>
+       <shortname>AVE_PRES_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>PRES</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>502</post_avblfldidx>
+       <shortname>AVE_TMP_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TMP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>503</post_avblfldidx>
+       <shortname>AVE_AKHS_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>AKHS</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>504</post_avblfldidx>
+       <shortname>AVE_AKMS_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>AKMS</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>505</post_avblfldidx>
+       <shortname>TMP_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>506</post_avblfldidx>
+       <shortname>MAX_MAXUW_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <longname>U Component of Hourly Maximum 10m Wind Speed (m/s)</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MAXUW</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>507</post_avblfldidx>
+       <shortname>MAX_MAXVW_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <longname>V Component of Hourly Maximum 10m Wind Speed (m/s)</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MAXVW</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>508</post_avblfldidx>
+       <shortname>MAX_PRATE_ON_SURFACE</shortname>
+       <longname>Maximum Precipitation Rate on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PRATE</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>510</post_avblfldidx>
+       <shortname>MAX_QMAX_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>QMAX</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>511</post_avblfldidx>
+       <shortname>MIN_QMIN_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>QMIN</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>512</post_avblfldidx>
+       <shortname>ACOND_ON_SURFACE</shortname>
+       <pname>ACOND</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>513</post_avblfldidx>
+       <shortname>AVE_EVCW_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>EVCW</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>514</post_avblfldidx>
+       <shortname>AVE_EVBS_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>EVBS</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>515</post_avblfldidx>
+       <shortname>AVE_TRANS_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>TRANS</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>516</post_avblfldidx>
+       <shortname>AVE_SBSNO_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SBSNO</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>517</post_avblfldidx>
+       <shortname>AVE_PEVPR_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PEVPR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+<!-- 518-525 on std_isobaric_sfc for WAFS products  -->
+    <param>
+       <post_avblfldidx>518</post_avblfldidx>
+       <shortname>HGT_ON_ICAO_STD_SFC</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>519</post_avblfldidx>
+       <shortname>TMP_ON_ICAO_STD_SFC</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>520</post_avblfldidx>
+       <shortname>UGRD_ON_ICAO_STD_SFC</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>521</post_avblfldidx>
+       <shortname>VGRD_ON_ICAO_STD_SFC</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>522</post_avblfldidx>
+       <shortname>RH_ON_ICAO_STD_SFC</shortname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>523</post_avblfldidx>
+       <shortname>VVEL_ON_ICAO_STD_SFC</shortname>
+       <pname>VVEL</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>524</post_avblfldidx>
+       <shortname>ABSV_ON_ICAO_STD_SFC</shortname>
+       <pname>ABSV</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>525</post_avblfldidx>
+       <shortname>CLMR_ON_ICAO_STD_SFC</shortname>
+       <pname>CLMR</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>526</post_avblfldidx>
+       <shortname>BUCKET1_APCP_ON_SURFACE</shortname>
+       <longname>bucket Total precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>APCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>527</post_avblfldidx>
+       <shortname>BUCKET1_ACPCP_ON_SURFACE</shortname>
+       <longname>bucket Convective precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ACPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>528</post_avblfldidx>
+       <shortname>BUCKET1_NCPCP_ON_SURFACE</shortname>
+       <longname>bucket Large scale precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>NCPCP</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>529</post_avblfldidx>
+       <shortname>BUCKET1_WEASD_ON_SURFACE</shortname>
+       <longname>bucket snow precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>WEASD</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+   <param>
+       <post_avblfldidx>530</post_avblfldidx>
+       <shortname>BUCKET1_GRAUPEL_ON_SURFACE</shortname>
+       <longname>bucket graupel precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FROZR</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+   <param>
+       <post_avblfldidx>546</post_avblfldidx>
+       <shortname>GSD_POT_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>POT</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+
+    <param>
+       <post_avblfldidx>547</post_avblfldidx>
+       <shortname>GSD_DEPR_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>DEPR</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>548</post_avblfldidx>
+       <shortname>GSD_EPOT_ON_SURFACE</shortname>
+       <pname>EPOT</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>549</post_avblfldidx>
+       <shortname>FDNSSTMP_ON_SURFACE</shortname>
+       <pname>FDNSSTMP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>551</post_avblfldidx>
+       <shortname>CSNOW_ON_SURFACE</shortname>
+       <longname>Categorical snow on surface</longname>
+       <pname>CSNOW</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>552</post_avblfldidx>
+       <shortname>CICEP_ON_SURFACE</shortname>
+       <longname>Categorical ice pellets on surface</longname>
+       <pname>CICEP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>553</post_avblfldidx>
+       <shortname>CFRZR_ON_SURFACE</shortname>
+       <longname>Categorical freezing rain on surface</longname>
+       <pname>CFRZR</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>555</post_avblfldidx>
+       <shortname>AVE_CSNOW_ON_SURFACE</shortname>
+       <longname>average Categorical snow on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CSNOW</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>556</post_avblfldidx>
+       <shortname>AVE_CICEP_ON_SURFACE</shortname>
+       <longname>average Categorical ice pellets on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CICEP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>557</post_avblfldidx>
+       <shortname>AVE_CFRZR_ON_SURFACE</shortname>
+       <longname>average Categorical freezing rain on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CFRZR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>559</post_avblfldidx>
+       <shortname>GSD_CSNOW_ON_SURFACE</shortname>
+       <longname>GSD_Categorical snow on surface</longname>
+       <pname>CSNOW</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>560</post_avblfldidx>
+       <shortname>GSD_CICEP_ON_SURFACE</shortname>
+       <longname>GSD_Categorical ice pellets on surface</longname>
+       <pname>CICEP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>561</post_avblfldidx>
+       <shortname>GSD_CFRZR_ON_SURFACE</shortname>
+       <longname>GSD_Categorical freezing rain on surface</longname>
+       <pname>CFRZR</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>563</post_avblfldidx>
+       <shortname>GSD_AVE_CSNOW_ON_SURFACE</shortname>
+       <longname>GSD_average Categorical snow on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CSNOW</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>564</post_avblfldidx>
+       <shortname>GSD_AVE_CICEP_ON_SURFACE</shortname>
+       <longname>GSD_average Categorical ice pellets on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CICEP</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>565</post_avblfldidx>
+       <shortname>GSD_AVE_CFRZR_ON_SURFACE</shortname>
+       <longname>GSD_average Categorical freezing rain on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>CFRZR</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>1.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>566</post_avblfldidx>
+       <shortname>BEST_CAPE_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>567</post_avblfldidx>
+       <shortname>BEST_CIN_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>568</post_avblfldidx>
+       <shortname>GFS_PRES_ON_MEAN_SEA_LVL</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>mean_sea_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>569</post_avblfldidx>
+       <shortname>GFS_AVE_TCDC_ON_CONVECTIVE_CLOUD_LYR</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>TCDC</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>convective_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>570</post_avblfldidx>
+       <shortname>GFS_TCDC_ON_CONVECTIVE_CLOUD_LYR</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>convective_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>571</post_avblfldidx>
+       <shortname>GFS_TMP_ON_DEPTH_BEL_LAND_SFC_3m</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <level>3.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>572</post_avblfldidx>
+       <shortname>GFS_LFTX_ON_SURFACE</shortname>
+       <pname>LFTX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>573</post_avblfldidx>
+       <shortname>GFS_4LFTX_ON_SURFACE</shortname>
+       <pname>4LFTX</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>574</post_avblfldidx>
+       <shortname>GFS_TMP_ON_DEPTH_BEL_LAND_SFC</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>depth_bel_land_sfc</fixed_sfc1_type>
+       <fixed_sfc2_type>depth_bel_land_sfc</fixed_sfc2_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>575</post_avblfldidx>
+       <shortname>CWAT_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pname>CWAT</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>576</post_avblfldidx>
+       <shortname>UGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>UGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>577</post_avblfldidx>
+       <shortname>VGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>VGRD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>578</post_avblfldidx>
+       <shortname>SPFH_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>SPFH</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>579</post_avblfldidx>
+       <shortname>PRES_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>580</post_avblfldidx>
+       <shortname>ICI_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pname>ICI</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>581</post_avblfldidx>
+       <shortname>VIL_ON_ENTIRE_ATMOS</shortname>
+       <longname>entire atmosphere Vertically Integrated Liquid (kg/m-2)</longname>
+       <pname>VIL</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>582</post_avblfldidx>
+       <shortname>MIXED_LAYER_CAPE_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>583</post_avblfldidx>
+       <shortname>MIXED_LAYER_CIN_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>584</post_avblfldidx>
+       <shortname>UNSTABLE_CAPE_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>585</post_avblfldidx>
+       <shortname>UNSTABLE_CIN_ON_SPEC_PRES_ABOVE_GRND</shortname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+    </param>
+
+    <param>
+       <post_avblfldidx>586</post_avblfldidx>
+       <shortname>TMP_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>587</post_avblfldidx>
+       <shortname>ICI_ON_SPEC_HGT_LVL_ABOVE_GRND_FDHGT</shortname>
+       <pname>ICI</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>588</post_avblfldidx>
+       <shortname>ICEG_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL</shortname>
+       <pname>ICEG</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>601</post_avblfldidx>
+       <shortname>DUST1_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>2</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>20</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>602</post_avblfldidx>
+       <shortname>DUST2_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>36</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>603</post_avblfldidx>
+       <shortname>DUST3_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>36</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>60</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>604</post_avblfldidx>
+       <shortname>DUST4_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>60</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>120</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>605</post_avblfldidx>
+       <shortname>DUST5_ON_SPEC_ALT_ABOVE_MEAN_SEA_LVL_FDHGT</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSMR</pname>
+       <fixed_sfc1_type>spec_alt_above_mean_sea_lvl</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>120</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>200</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+<!-- 606-608 -->
+    <param>
+       <post_avblfldidx>606</post_avblfldidx>
+       <shortname>AECOEF_ON_HYBRID_LVL</shortname>
+       <pname>AECOFF</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>607</post_avblfldidx>
+       <shortname>ASYSFK_ON_HYBRID_LVL</shortname>
+       <pname>ASYSFK</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>608</post_avblfldidx>
+       <shortname>SSALBK_ON_HYBRID_LVL</shortname>
+       <pname>SSALBK</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>609</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>610</post_avblfldidx>
+       <shortname>DUST_AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>611</post_avblfldidx>
+       <shortname>SEASALT_AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>612</post_avblfldidx>
+       <shortname>SULFATE_AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>613</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>614</post_avblfldidx>
+       <shortname>BLACK_CARBON_AER_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>616</post_avblfldidx>
+       <shortname>BC_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>236</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>617</post_avblfldidx>
+       <shortname>OC_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>424</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>618</post_avblfldidx>
+       <shortname>SULF_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+    <param>
+       <post_avblfldidx>619</post_avblfldidx>
+       <shortname>PM10_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTC</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>620</post_avblfldidx>
+       <shortname>PM25_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>621</post_avblfldidx>
+       <shortname>PM10_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>622</post_avblfldidx>
+       <shortname>PM25_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>623</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at340</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>338</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>342</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>624</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at440</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>430</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>450</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>625</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at660</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>620</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>670</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>626</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at860</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>841</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>876</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>627</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at1630</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>	   
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>1628</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>1652</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>628</post_avblfldidx>
+       <shortname>AER_OPT_DEP_at11100</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>11000</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>11200</scale_val_2nd_wvlen>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>629</post_avblfldidx>
+       <shortname>DUST1_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>	   
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>2</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>20</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>630</post_avblfldidx>
+       <shortname>DUST2_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>	   
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>36</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>631</post_avblfldidx>
+       <shortname>DUST3_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTC</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>	   
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>36</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>60</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>632</post_avblfldidx>
+       <shortname>DUST4_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTC</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>	   
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>60</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>120</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>633</post_avblfldidx>
+       <shortname>DUST5_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTC</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>	   
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>120</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>200</scale_val_2nd_size>
+       <scale>11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>634</post_avblfldidx>
+       <shortname>SEASALT1_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>6</scale_val_1st_size>
+       <scale_fact_2nd_size>8</scale_fact_2nd_size>
+       <scale_val_2nd_size>20</scale_val_2nd_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>635</post_avblfldidx>
+       <shortname>SEASALT2_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> PMTF</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>2</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>10</scale_val_2nd_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>636</post_avblfldidx>
+       <shortname>SEASALT3_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> PMTC</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>30</scale_val_2nd_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>637</post_avblfldidx>
+       <shortname>SEASALT4_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> PMTC</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>30</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>100</scale_val_2nd_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>638</post_avblfldidx>
+       <shortname>SEASALT5_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> PMTC</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>between_first_second_limit_noincl2ndlmt</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>100</scale_val_1st_size>
+       <scale_fact_2nd_size>7</scale_fact_2nd_size>
+       <scale_val_2nd_size>200</scale_val_2nd_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>639</post_avblfldidx>
+       <shortname>SO4_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>equall_to_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>9</scale_fact_1st_size>
+       <scale_val_1st_size>139</scale_val_1st_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>640</post_avblfldidx>
+       <shortname>OCPHOBIC_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>particulate_org_matter_hydrophobic</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>equall_to_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>424</scale_val_1st_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>641</post_avblfldidx>
+       <shortname>OCPHILIC_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>particulate_org_matter_hydrophilic</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>equall_to_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>424</scale_val_1st_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>642</post_avblfldidx>
+       <shortname>BCPHOBIC_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>black_carbon_hydrophobic</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>equall_to_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>236</scale_val_1st_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>643</post_avblfldidx>
+       <shortname>BCPHILIC_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <aerosol_type>black_carbon_hydrophilic</aerosol_type>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <typ_intvl_size>equall_to_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>236</scale_val_1st_size>
+       <scale> 11.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>644</post_avblfldidx>
+       <shortname>AIR_DENSITY_ON_HYBRID_LVL</shortname>
+       <pname>DEN</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>645</post_avblfldidx>
+       <shortname>LAYER_THICKNESS_ON_HYBRID_LVL</shortname>
+       <pname>THICK</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>646</post_avblfldidx>
+       <shortname>DUST_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>647</post_avblfldidx>
+       <shortname>SEAS_COL_MASS_DEN</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>648</post_avblfldidx>
+       <shortname>SINGLE_SCAT_ALBD_at340</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SSALBK</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>338</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>342</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>649</post_avblfldidx>
+       <shortname>AER_ASYM_FACTOR_at340</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> ASYSFK</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>338</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>342</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>650</post_avblfldidx>
+       <shortname>AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>651</post_avblfldidx>
+       <shortname>DUST_AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>652</post_avblfldidx>
+       <shortname>SEASALT_AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>653</post_avblfldidx>
+       <shortname>SULFATE_AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>654</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>655</post_avblfldidx>
+       <shortname>BLACK_CARBON_AER_SCAT_OPT_DEP_at550</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SCTAOTK</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>545</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>565</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>656</post_avblfldidx>
+       <shortname>ANGSTROM_EXP_at440_860</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> ANGSTEXP</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <typ_intvl_wvlen>between_first_second_limit</typ_intvl_wvlen>
+       <scale_fact_1st_wvlen>9</scale_fact_1st_wvlen>
+       <scale_val_1st_wvlen>430</scale_val_1st_wvlen>
+       <scale_fact_2nd_wvlen>9</scale_fact_2nd_wvlen>
+       <scale_val_2nd_wvlen>876</scale_val_2nd_wvlen>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>659</post_avblfldidx>
+       <shortname>DUST_EMISSION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>AEMFLX</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>660</post_avblfldidx>
+       <shortname>DUST_SEDIMENTATION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>SEDMFLX</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>661</post_avblfldidx>
+       <shortname>DUST DRY DEPOSITION</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>DDMFLX</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>662</post_avblfldidx>
+       <shortname>DUST WET DEPOSITION</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>WLSMFLX</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>663</post_avblfldidx>
+       <shortname>SEASALT_EMISSION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> AEMFLX</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>664</post_avblfldidx>
+       <shortname>SEASALT_SEDIMENTATION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SEDMFLX</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>665</post_avblfldidx>
+       <shortname>SEASALT_DRY_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> DDMFLX</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>666</post_avblfldidx>
+       <shortname>SEASALT_WET_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WLSMFLX</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>667</post_avblfldidx>
+       <shortname>BLACK_CARBON_EMISSION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> AEMFLX</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>10</scale_fact_1st_size>
+       <scale_val_1st_size>236</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>668</post_avblfldidx>
+       <shortname>BLACK_CARBON_SEDIMENTATION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SEDMFLX</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>669</post_avblfldidx>
+       <shortname>BLACK_CARBON_DRY_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> DDMFLX</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>670</post_avblfldidx>
+       <shortname>BLACK_CARBON_WET_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WLSMFLX</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>671</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_EMISSION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> AEMFLX</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>672</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_SEDIMENTATION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SEDMFLX</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>673</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_DRY_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> DDMFLX</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>674</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_WET_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WLSMFLX</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>675</post_avblfldidx>
+       <shortname>SULFATE_EMISSION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> AEMFLX</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>676</post_avblfldidx>
+       <shortname>SULFATE_SEDIMENTATION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> SEDMFLX</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>677</post_avblfldidx>
+       <shortname>SULFATE_DRY_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> DDMFLX</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>678</post_avblfldidx>
+       <shortname>SULFATE_WET_DEPOSITION_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WLSMFLX</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>679</post_avblfldidx>
+       <shortname>DUST_SCAVENGING_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WDCPMFLX</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>680</post_avblfldidx>
+       <shortname>SEASALT_SCAVENGING_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WDCPMFLX</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>20</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>681</post_avblfldidx>
+       <shortname>BLACK_CARBON_SCAVENGING_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WDCPMFLX</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>682</post_avblfldidx>
+       <shortname>ORGANIC_CARBON_SCAVENGING_FLUX</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname> WDCPMFLX</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>8</scale_fact_1st_size>
+       <scale_val_1st_size>70</scale_val_1st_size>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>683</post_avblfldidx>
+       <shortname>SS_CR_AER_SFC_MASS_CON</shortname>
+       <stats_proc>AVE</stats_proc>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>684</post_avblfldidx>
+       <shortname>SEAS25_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>685</post_avblfldidx>
+       <shortname>DU_CR_AER_SFC_MASS_CON</shortname>
+       <stats_proc>AVE</stats_proc>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>686</post_avblfldidx>
+       <shortname>DUST25_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>PMTF</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>687</post_avblfldidx>
+       <shortname>BC_AER_SFC_MASS_CON</shortname>
+       <stats_proc>AVE</stats_proc>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>688</post_avblfldidx>
+       <shortname>OC_AER_SFC_MASS_CON</shortname>
+       <stats_proc>AVE</stats_proc>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>689</post_avblfldidx>
+       <shortname>SU_AER_SFC_MASS_CON</shortname>
+       <stats_proc>AVE</stats_proc>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>690</post_avblfldidx>
+       <shortname>INST_SU_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>sulphate_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>691</post_avblfldidx>
+       <shortname>INST_OC_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>particulate_org_matter_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+
+    <param>
+       <post_avblfldidx>692</post_avblfldidx>
+       <shortname>INST_BC_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>black_carbon_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>693</post_avblfldidx>
+       <shortname>INST_DU_CR_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>694</post_avblfldidx>
+       <shortname>INST_DU_FN_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>dust_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>695</post_avblfldidx>
+       <shortname>INST_SS_CR_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>696</post_avblfldidx>
+       <shortname>INST_SS_FN_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>sea_salt_dry</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>697</post_avblfldidx>
+       <shortname>INST_CR_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>6</scale_fact_1st_size>
+       <scale_val_1st_size>10</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>698</post_avblfldidx>
+       <shortname>INST_FN_AER_SFC_MASS_CON</shortname>
+       <pdstmpl>tmpl4_48</pdstmpl>
+       <pname>MASSDEN</pname>
+       <aerosol_type>total_aerosol</aerosol_type>
+       <typ_intvl_size>smaller_than_first_limit</typ_intvl_size>
+       <scale_fact_1st_size>7</scale_fact_1st_size>
+       <scale_val_1st_size>25</scale_val_1st_size>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale> 9.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>700</post_avblfldidx>
+       <shortname>GSD_MAX_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_1-6km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>	   
+       <pname>MXUPHL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>6000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>1000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>701</post_avblfldidx>
+       <shortname>GSD_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_1-6km</shortname>
+       <pname>UPHL</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>6000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>1000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <!-- no grib2 definition for 702-710 -->
+    <param>
+       <post_avblfldidx>702</post_avblfldidx>
+       <shortname>GSD_MAX_LTG_THREAT1_ON_ENTIRE_ATMOS</shortname>
+       <pname>LTGTHREAT1</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>703</post_avblfldidx>
+       <shortname>GSD_MAX_LTG_THREAT2_ON_ENTIRE_ATMOS</shortname>
+       <pname>LTGTHREAT2</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>704</post_avblfldidx>
+       <shortname>GSD_MAX_LTG_THREAT3_ON_ENTIRE_ATMOS</shortname>
+       <pname>LTNG</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>705</post_avblfldidx>
+       <shortname>GSD_NCI_LTG_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Initiation Lightning</longname>
+       <pname>NCILTG</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>706</post_avblfldidx>
+       <shortname>GSD_NCA_LTG_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Activity Lightning</longname>
+       <pname>NCALTG</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>707</post_avblfldidx>
+       <shortname>GSD_NCI_WQ_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Initiation Vertical Hydrometeor Flux</longname>
+       <pname>NCIWQ</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>708</post_avblfldidx>
+       <shortname>GSD_NCA_WQ_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Activity Vertical Hydrometeor Flux</longname>
+       <pname>NCAWQ</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>709</post_avblfldidx>
+       <shortname>GSD_NCI_REFL_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Initiation Reflectivity</longname>
+       <pname>TSEC</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>710</post_avblfldidx>
+       <shortname>GSD_NCA_REFL_ON_ENTIRE_ATMOS</shortname>
+       <longname>GSD_Convective Activity Reflectivity</longname>
+       <pname>TSEC</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <level>6.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>711</post_avblfldidx>
+       <shortname>GSD_EXP_CEILING_2</shortname>
+       <pname>CEIL</pname>
+       <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>719</post_avblfldidx>
+       <shortname>INST_USWRF_ON_TOP_OF_ATMOS</shortname>
+       <pname>USWRF</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>725</post_avblfldidx>
+       <shortname>GSD_ACM_SNOD_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>ASNOW</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>726</post_avblfldidx>
+       <shortname>VEG_MIN_ON_SURFACE</shortname>
+       <pname>VEGMIN</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>727</post_avblfldidx>
+       <shortname>GSD_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_2-5km</shortname>
+       <pname>UPHL</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>5000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>2000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+   <param>
+       <post_avblfldidx>728</post_avblfldidx>
+       <shortname>GSD_HAILCAST_HAIL_DIAMETER</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>HAIL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>729</post_avblfldidx>
+       <shortname>VEG_MAX_ON_SURFACE</shortname>
+       <pname>VEGMAX</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>730</post_avblfldidx>
+       <shortname>AVE_WIND_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>WIND</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>731</post_avblfldidx>
+       <shortname>AVE_UGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>UGRD</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>732</post_avblfldidx>
+       <shortname>AVE_VGRD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>VGRD</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>733</post_avblfldidx>
+       <shortname>GSD_AVE_DSWRF_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>DSWRF</pname>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>734</post_avblfldidx>
+       <shortname>GSD_AVE_SWDDNI_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>VBDSF</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>735</post_avblfldidx>
+       <shortname>AOD_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pdstmpl>tmpl4_0</pdstmpl>
+       <pname>AOTK</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>736</post_avblfldidx>
+       <shortname>SMOKE_ON_ENTIRE_ATMOS_SINGLE_LYR</shortname>
+       <pdstmpl>tmpl4_0</pdstmpl>
+       <pname>COLMD</pname>
+       <fixed_sfc1_type>entire_atmos_single_lyr</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>737</post_avblfldidx>
+       <shortname>SMOKE_ON_HYBRID_LVL</shortname>
+       <pdstmpl>tmpl4_0</pdstmpl>
+       <pname>MASSDEN</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>738</post_avblfldidx>
+       <shortname>SMOKE_ON_ISOBARIC_SFC</shortname>
+       <pdstmpl>tmpl4_0</pdstmpl>
+       <pname>MASSDEN</pname>
+       <fixed_sfc1_type>isobaric_sfc</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>739</post_avblfldidx>
+       <shortname>SMOKE_ON_SPEC_HGT_LVL_ABOVE_GRND_8m</shortname>
+       <pdstmpl>tmpl4_0</pdstmpl>
+       <pname>MASSDEN</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>8.</level>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>740</post_avblfldidx>
+       <shortname>MEAN_FIRE_RDIATV_PWR</shortname>
+       <pname>CFNSF</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+   <param>
+       <post_avblfldidx>746</post_avblfldidx>
+       <shortname>ACM_GRAUPEL_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FROZR</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>747</post_avblfldidx>
+       <shortname>GSD_NCCD_ON_HYBRID_LVL</shortname>
+       <longname>Number concentration for cloud water drops on hybrid level</longname>
+       <pname>NCONCD</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>748</post_avblfldidx>
+       <shortname>GSD_REFL_ON_SPEC_HGT_LVL_ABOVE_GRND_1km</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>1000.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>749</post_avblfldidx>
+       <shortname>GSD_RH_WRT_PRECIP_WATER_ON_ENTIRE_ATMOS</shortname>
+       <longname>RELATIVE HUMIDITY WITH RESPECT TO PRECIPITABLE WATER</longname>
+       <pname>RH_PWAT</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>750</post_avblfldidx>
+       <shortname>GSD_WV_MIXR_ON_HYBRID_LVL</shortname>
+       <pname>MIXR</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>751</post_avblfldidx>
+       <shortname>GSD_VPTMP_ON_HYBRID_LVL</shortname>
+       <pname>VPTMP</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>752</post_avblfldidx>
+       <shortname>GSD_NCIP_ON_HYBRID_LVL</shortname>
+       <longname>Number concentration for ice particles on hybrid level</longname>
+       <pname>NCIP</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>753</post_avblfldidx>
+       <shortname>GSD_PRES_ON_0C_ISOTHERM</shortname>
+       <longname>GSD_pressure on Level of 0 deg (C) isotherm</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>0C_isotherm</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>754</post_avblfldidx>
+       <shortname>GSD_NCRAIN_ON_HYBRID_LVL</shortname>
+       <pname>NCRAIN</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>756</post_avblfldidx>
+       <shortname>GSD_PRES_ON_HGHST_TROP_FRZ_LVL</shortname>
+       <longname>GSD_pressure on Highest tropospheric freezing level</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>hghst_trop_frz_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>757</post_avblfldidx>
+       <shortname>GSD_REFL_ON_SPEC_HGT_LVL_ABOVE_GRND_4km</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>4000.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>758</post_avblfldidx>
+       <shortname>GSD_HGT_ON_CONVECTIVE_CLOUD_TOP_LVL</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>convective_cloud_top_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>760</post_avblfldidx>
+       <shortname>GSD_MIXR_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>MIXR</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>761</post_avblfldidx>
+       <shortname>GSD_INSIDE_SNOW_TMP_ON_SURFACE</shortname>
+       <pname>TMP</pname>
+       <fixed_sfc1_type>SURFACE</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>762</post_avblfldidx>
+       <shortname>GSD_MIXR_ON_SURFACE</shortname>
+       <pname>MIXR</pname>
+       <fixed_sfc1_type>SURFACE</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>763</post_avblfldidx>
+       <shortname>GSD_MIXR_ON_LFC</shortname>
+       <pname>MIXR</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>766</post_avblfldidx>
+       <shortname>GSD_NCWFA_ON_HYBRID_LVL</shortname>
+       <pname>PMTF</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>767</post_avblfldidx>
+       <shortname>GSD_NCIFA_ON_HYBRID_LVL</shortname>
+       <pname>PMTC</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>768</post_avblfldidx>
+       <shortname>GSD_ECHOTOP_ON_CLOUD_TOP</shortname>
+       <longname>Echo top height (Highest height in meters of the 18-dBZ reflectivity on a model level)</longname>
+       <pname>RETOP</pname>
+       <fixed_sfc1_type>cloud_top</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>769</post_avblfldidx>
+       <shortname>GSD_VIL_ON_ENTIRE_ATMOS</shortname>
+       <pname>VIL</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>770</post_avblfldidx>
+       <shortname>GSD_RADARVIL_ON_ENTIRE_ATMOS</shortname>
+       <pname>RADARVIL</pname>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>772</post_avblfldidx>
+       <shortname>INST_SWDDNI_ON_SURFACE</shortname>
+       <pname>VBDSF</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>773</post_avblfldidx>
+       <shortname>INST_SWDDIF_ON_SURFACE</shortname>
+       <pname>VDDSF</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>774</post_avblfldidx>
+       <shortname>FRACCC_ON_HYBRID_LVL</shortname>
+       <pname>FRACCC</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>775</post_avblfldidx>
+       <shortname>BUCKET_GRAUPEL_ON_SURFACE</shortname>
+       <longname>bucket graupel precipitation on surface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FROZR</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>776</post_avblfldidx>
+       <shortname>HGT_ON_HGHST_TROP_-10C_LVL</shortname>
+       <longname>height on highest tropospheric -10C level</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>263.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>777</post_avblfldidx>
+       <shortname>RH_ON_HGHST_TROP_-10C_LVL</shortname>
+       <longname>relative humidity on highest tropospheric -10C level</longname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>263.</level>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>778</post_avblfldidx>
+       <shortname>PRES_ON_HGHST_TROP_-10C_LVL</shortname>
+       <longname>pressure on highest tropospheric -10C level</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>263.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>779</post_avblfldidx>
+       <shortname>HGT_ON_HGHST_TROP_-20C_LVL</shortname>
+       <longname>height on highest tropospheric -20C level</longname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>253.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>780</post_avblfldidx>
+       <shortname>RH_ON_HGHST_TROP_-20C_LVL</shortname>
+       <longname>relative humidity on highest tropospheric -20C level</longname>
+       <pname>RH</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>253.</level>
+       <scale>2.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>781</post_avblfldidx>
+       <shortname>PRES_ON_HGHST_TROP_-20C_LVL</shortname>
+       <longname>pressure on highest tropospheric -20C level</longname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>253.</level>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>782</post_avblfldidx>
+       <shortname>ACM_FRAIN_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FRZR</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>783</post_avblfldidx>
+       <shortname>MAX_UGD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <longname>maximum u wind on 10 meter Above Ground</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MAXUW</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>784</post_avblfldidx>
+       <shortname>MAX_VGD_ON_SPEC_HGT_LVL_ABOVE_GRND_10m</shortname>
+       <longname>maximum v wind on 10 meter Above Ground</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MAXVW</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>10.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>785</post_avblfldidx>
+       <shortname>MAX_REF_ON_ISOTHERMAL_-10C</shortname>
+       <longname>maximum reflectivity on -10C suface</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>REFD</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>263.</level>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>786</post_avblfldidx>
+       <shortname>GSD_MIN_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_2-5km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MNUPHL</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>5000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>2000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>787</post_avblfldidx>
+       <shortname>GSD_MIN_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_1-6km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MNUPHL</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>6000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>1000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>788</post_avblfldidx>
+       <shortname>GSD_MAX_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_0-2km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MXUPHL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>789</post_avblfldidx>
+       <shortname>GSD_MIN_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_0-2km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MNUPHL</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>790</post_avblfldidx>
+       <shortname>GSD_MAX_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_0-3km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MXUPHL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>3000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>791</post_avblfldidx>
+       <shortname>GSD_MIN_UPHL_ON_SPEC_HGT_LVL_ABOVE_GRND_0-3km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>MNUPHL</pname>
+       <stats_proc>MIN</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>3000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>-3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>792</post_avblfldidx>
+       <shortname>GSD_MAX_REL_VORT_ON_SPEC_HGT_LVL_ABOVE_GRND_0-2km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>RELV</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>5.0</scale>
+    </param>
+
+   <param>
+       <post_avblfldidx>793</post_avblfldidx>
+       <shortname>GSD_MAX_REL_VORT_ON_SPEC_HGT_LVL_ABOVE_GRND_0-1km</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>RELV</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>1000.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>0000.</level2>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>794</post_avblfldidx>
+       <shortname>GSD_MAX_COLMAX_GRAUPEL_HAIL_DIAMETER</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>HAIL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>entire_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>795</post_avblfldidx>
+       <shortname>GSD_MAX_SIGMA_LVL_MAX_GRAUPEL_HAIL_DIAMETER</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>HAIL</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>sigma_lvl</fixed_sfc1_type>
+       <scale_fact_fixed_sfc1>1</scale_fact_fixed_sfc1>
+       <level>1.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>798</post_avblfldidx>
+       <shortname>GSD_PRES1_ON_CLOUD_BASE</shortname>
+       <pname>PRES</pname>
+       <fixed_sfc1_type>cloud_base</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>799</post_avblfldidx>
+       <shortname>TCDC_ON_BOUND_LYR</shortname>
+       <pname>TCDC</pname>
+       <fixed_sfc1_type>bound_lyr_cloud_lyr</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>808</post_avblfldidx>
+       <shortname>APTMP_ON_SPEC_HGT_LVL_ABOVE_GRND_2m</shortname>
+       <pname>APTMP</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>2.</level>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>825</post_avblfldidx>
+       <shortname>SSMS1715_ON_TOP_OF_ATMOS</shortname>
+       <pname>SSMS1715</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>826</post_avblfldidx>
+       <shortname>SSMS1716_ON_TOP_OF_ATMOS</shortname>
+       <pname>SSMS1716</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>827</post_avblfldidx>
+       <shortname>SSMS1717_ON_TOP_OF_ATMOS</shortname>
+       <pname>SSMS1717</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>828</post_avblfldidx>
+       <shortname>SSMS1718_ON_TOP_OF_ATMOS</shortname>
+       <pname>SSMS1718</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>890</post_avblfldidx>
+       <shortname>GSD_MAX_REL_VORT_ON_SPEC_HGT_LVL_HYBRID1</shortname>
+       <longname>Hourly max relative vorticity on hybrid level 1</longname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>RELV</pname>
+       <stats_proc>MAX</stats_proc>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <level>1.</level>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>912</post_avblfldidx>
+       <shortname>REFD_ON_ISOTHERMAL</shortname>
+       <pname>REFD</pname>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>263.</level>
+       <scale>-4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>913</post_avblfldidx>
+       <shortname>1H_FFG_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>914</post_avblfldidx>
+       <shortname>ACM_FFG_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>915</post_avblfldidx>
+       <shortname>1H_2YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>916</post_avblfldidx>
+       <shortname>ACM_2YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>917</post_avblfldidx>
+       <shortname>1H_5YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>918</post_avblfldidx>
+       <shortname>ACM_5YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>919</post_avblfldidx>
+       <shortname>1H_10YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>920</post_avblfldidx>
+       <shortname>ACM_10YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>921</post_avblfldidx>
+       <shortname>1H_100YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>922</post_avblfldidx>
+       <shortname>ACM_100YARI_EXCEEDANCE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>FFLDRO</pname>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>927</post_avblfldidx>
+       <shortname>SBTA167_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA167</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>928</post_avblfldidx>
+       <shortname>SBTA168_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA168</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>929</post_avblfldidx>
+       <shortname>SBTA169_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA169</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>930</post_avblfldidx>
+       <shortname>SBTA1610_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1610</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>931</post_avblfldidx>
+       <shortname>SBTA1611_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1611</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>932</post_avblfldidx>
+       <shortname>SBTA1612_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1612</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>933</post_avblfldidx>
+       <shortname>SBTA1613_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1613</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>934</post_avblfldidx>
+       <shortname>SBTA1614_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1614</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>935</post_avblfldidx>
+       <shortname>SBTA1615_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1615</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>936</post_avblfldidx>
+       <shortname>SBTA1616_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1616</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>937</post_avblfldidx>
+       <shortname>SBTA177_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA177</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>938</post_avblfldidx>
+       <shortname>SBTA178_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA178</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>939</post_avblfldidx>
+       <shortname>SBTA179_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA179</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>940</post_avblfldidx>
+       <shortname>SBTA1710_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1710</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>941</post_avblfldidx>
+       <shortname>SBTA1711_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1711</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>942</post_avblfldidx>
+       <shortname>SBTA1712_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1712</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>943</post_avblfldidx>
+       <shortname>SBTA1713_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1713</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>944</post_avblfldidx>
+       <shortname>SBTA1714_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1714</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>945</post_avblfldidx>
+       <shortname>SBTA1715_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1715</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>946</post_avblfldidx>
+       <shortname>SBTA1716_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTA1716</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>950</post_avblfldidx>
+       <shortname>CAPE_ON_0_3KM_ABOVE_GRND</shortname>
+       <pname>CAPE</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>3000.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>951</post_avblfldidx>
+       <shortname>CIN_ON_0_3KM_ABOVE_GRND</shortname>
+       <pname>CIN</pname>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>3000.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>952</post_avblfldidx>
+       <shortname>HGT_ON_LFC</shortname>
+       <pname>HGT</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>953</post_avblfldidx>
+       <shortname>EFF_HLCY_ON_SPEC_HGT_LVL_ABOVE_GRND</shortname>
+       <pname>EFHL</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>954</post_avblfldidx>
+       <shortname>DOWNWARD_CAPE</shortname>
+       <pname>DCAPE</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>spec_pres_above_grnd</fixed_sfc1_type>
+       <level>40000.</level>
+       <fixed_sfc2_type>spec_pres_above_grnd</fixed_sfc2_type>
+       <level2>0.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>955</post_avblfldidx>
+       <shortname>DENDRITIC_LAYER_DEPTH</shortname>
+       <pname>LAYTH</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>isothermal</fixed_sfc1_type>
+       <level>261.</level>
+       <fixed_sfc2_type>isothermal</fixed_sfc2_type>
+       <level2>256.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>956</post_avblfldidx>
+       <shortname>ENHANCED_STRETCHING_POTENTIAL</shortname>
+       <pname>ESP</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>3000.</level2>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>957</post_avblfldidx>
+       <shortname>CRITICAL_ANGLE</shortname>
+       <pname>DCAPE</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>spec_hgt_lvl_above_grnd</fixed_sfc1_type>
+       <level>0.</level>
+       <fixed_sfc2_type>spec_hgt_lvl_above_grnd</fixed_sfc2_type>
+       <level2>500.</level2>
+       <scale>4.0</scale>
+    </param>
+
+
+    <param>
+       <post_avblfldidx>958</post_avblfldidx>
+       <shortname>SBTAGR7_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR7</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>959</post_avblfldidx>
+       <shortname>SBTAGR8_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR8</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>960</post_avblfldidx>
+       <shortname>SBTAGR9_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>961</post_avblfldidx>
+       <shortname>SBTAGR10_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>962</post_avblfldidx>
+       <shortname>SBTAGR11_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>963</post_avblfldidx>
+       <shortname>SBTAGR12_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>964</post_avblfldidx>
+       <shortname>SBTAGR13_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR13</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>965</post_avblfldidx>
+       <shortname>SBTAGR14_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR14</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>966</post_avblfldidx>
+       <shortname>SBTAGR15_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR15</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>967</post_avblfldidx>
+       <shortname>SBTAGR16_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAGR16</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>968</post_avblfldidx>
+       <shortname>ICETMP_ON_SURFACE</shortname>
+       <pname>ICETMP</pname>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>5.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>969</post_avblfldidx>
+       <shortname>SBTAHI7_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI7</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>970</post_avblfldidx>
+       <shortname>SBTAHI8_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI8</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>971</post_avblfldidx>
+       <shortname>SBTAHI9_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI9</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>972</post_avblfldidx>
+       <shortname>SBTAHI10_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI10</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>973</post_avblfldidx>
+       <shortname>SBTAHI11_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI11</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>974</post_avblfldidx>
+       <shortname>SBTAHI12_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI12</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>975</post_avblfldidx>
+       <shortname>SBTAHI13_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI13</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>976</post_avblfldidx>
+       <shortname>SBTAHI14_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI14</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>977</post_avblfldidx>
+       <shortname>SBTAHI15_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI15</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>978</post_avblfldidx>
+       <shortname>SBTAHI16_ON_TOP_OF_ATMOS</shortname>
+       <pname>SBTAHI16</pname>
+       <fixed_sfc1_type>top_of_atmos</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>979</post_avblfldidx>
+       <shortname>EFSH_ON_LFC</shortname>
+       <pname>EFSH</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>980</post_avblfldidx>
+       <shortname>EFSH_ON_EQUIL_LVL</shortname>
+       <pname>EFSH</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>equil_lvl</fixed_sfc1_type>
+       <scale>4.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>982</post_avblfldidx>
+       <shortname>ELMELT_ON_EQUIL_LVL</shortname>
+       <pname>ELMELT</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>equil_lvl</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>983</post_avblfldidx>
+       <shortname>UESH_ON_LFC</shortname>
+       <pname>UESH</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>984</post_avblfldidx>
+       <shortname>VESH_ON_LFC</shortname>
+       <pname>VESH</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>985</post_avblfldidx>
+       <shortname>ESHR_ON_LFC</shortname>
+       <pname>ESHR</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>986</post_avblfldidx>
+       <shortname>UEID_ON_LFC</shortname>
+       <pname>UEID</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>987</post_avblfldidx>
+       <shortname>VEID_ON_LFC</shortname>
+       <pname>VEID</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>988</post_avblfldidx>
+       <shortname>E3KH_ON_LFC</shortname>
+       <pname>E3KH</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>989</post_avblfldidx>
+       <shortname>STPC_ON_LFC</shortname>
+       <pname>STPC</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>990</post_avblfldidx>
+       <shortname>SIGT_ON_LFC</shortname>
+       <pname>SIGT</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>991</post_avblfldidx>
+       <shortname>SCCP_ON_LFC</shortname>
+       <pname>SCCP</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>992</post_avblfldidx>
+       <shortname>MLFC_ON_LFC</shortname>
+       <pname>MLFC</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>993</post_avblfldidx>
+       <shortname>SIGH_ON_LFC</shortname>
+       <pname>SIGH</pname>
+       <fixed_sfc1_type>level_free_convection</fixed_sfc1_type>
+       <scale>6.0</scale>
+    </param>
+    
+    <param>
+       <post_avblfldidx>994</post_avblfldidx>
+       <shortname>OZCON_ON_HYBRID_LVL</shortname>
+       <pname>OZCON</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>7.0</scale>
+    </param>
+    
+    <param>
+       <post_avblfldidx>995</post_avblfldidx>
+       <shortname>PM25TOT_ON_HYBRID_LVL</shortname>
+       <pname>PMTF</pname>
+       <fixed_sfc1_type>hybrid_lvl</fixed_sfc1_type>
+       <scale>7.0</scale>
+    </param>
+    
+    <param>
+       <post_avblfldidx>996</post_avblfldidx>
+       <shortname>LAND_FRAC</shortname>
+       <pname>LANDFRC</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>997</post_avblfldidx>
+       <shortname>INST_PREC_ADVEC_HEAT</shortname>
+       <pname>PAHFLX</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>998</post_avblfldidx>
+       <shortname>WATER_AQUIFER</shortname>
+       <pname>WATERSA</pname>
+       <table_info>NCEP</table_info>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>999</post_avblfldidx>
+       <shortname>ACM_EIWATER_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>EIWATER</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>1000</post_avblfldidx>
+       <shortname>ACM_PLANTTR_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PLANTTR</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>1001</post_avblfldidx>
+       <shortname>ACM_SOILSE_ON_SURFACE</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>SOILSE</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>ACM</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>
+
+    <param>
+       <post_avblfldidx>1002</post_avblfldidx>
+       <shortname>AVE_PREC_ADVEC_HEAT</shortname>
+       <pdstmpl>tmpl4_8</pdstmpl>
+       <pname>PAHFLX</pname>
+       <table_info>NCEP</table_info>
+       <stats_proc>AVE</stats_proc>
+       <fixed_sfc1_type>surface</fixed_sfc1_type>
+       <scale>3.0</scale>
+    </param>  
+  </post_avblflds>
+</postxml>

--- a/fix/upp/postxconfig-NT-fv3lam_rrfs.txt
+++ b/fix/upp/postxconfig-NT-fv3lam_rrfs.txt
@@ -1,6 +1,6 @@
 2
 220
-253
+254
 BGDAWP
 32769
 ncep_nco
@@ -7863,7 +7863,7 @@ hghst_top_lvl_of_supercooled_liq_water_lyr
 ?
 408
 GSD_HGT_ON_CLOUD_CEILING
-GSD_geopotential height on cloud base
+GSD_geopotential height on cloud ceiling
 1
 tmpl4_0
 HGT
@@ -7906,7 +7906,7 @@ tmpl4_0
 CEIL
 ?
 ?
-ceiling
+cloud_ceilng
 0
 ?
 0
@@ -8787,19 +8787,19 @@ spec_hgt_lvl_above_grnd
 ?
 ?
 423
-MAX_MAXUVV_ON_ISOBARIC_SFC_10-100hpa
-hourly maximum Upward Vertical Velocity between 10-100hpa
+MAX_MAXUVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa
+hourly maximum Upward Vertical Velocity between 100-1000hpa
 1
 tmpl4_8
 MAXUVV
 NCEP
 MAX
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
 10000.
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
@@ -8824,19 +8824,19 @@ isobaric_sfc
 ?
 ?
 424
-MAX_MAXDVV_ON_ISOBARIC_SFC_10-100hpa
-hourly maximum Downward Vertical Velocity between 10-100hpa
+MAX_MAXDVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa
+hourly maximum Downward Vertical Velocity between 100-1000hpa
 1
 tmpl4_8
 MAXDVV
 NCEP
 MAX
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
 10000.
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
@@ -8854,6 +8854,43 @@ isobaric_sfc
 0.0
 1
 -3.0
+0
+0
+0
+?
+?
+?
+508
+MAX_PRATE_ON_SURFACE
+Maximum Precipitation Rate on surface
+1
+tmpl4_8
+PRATE
+?
+MAX
+surface
+0
+?
+0
+?
+?
+0
+?
+0
+?
+?
+?
+0
+0.0
+0
+0.0
+?
+0
+0.0
+0
+0.0
+1
+4.0
 0
 0
 0
@@ -10579,19 +10616,19 @@ surface
 ?
 ?
 423
-MAX_MAXUVV_ON_ISOBARIC_SFC_10-100hpa
-hourly maximum Upward Vertical Velocity between 10-100hpa
+MAX_MAXUVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa
+hourly maximum Upward Vertical Velocity between 100-1000hpa
 1
 tmpl4_8
 MAXUVV
 NCEP
 MAX
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
 10000.
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
@@ -10616,19 +10653,19 @@ isobaric_sfc
 ?
 ?
 424
-MAX_MAXDVV_ON_ISOBARIC_SFC_10-100hpa
-hourly maximum Downward Vertical Velocity between 10-100hpa
+MAX_MAXDVV_ON_SPEC_PRES_LVL_ABOVE_GRND_100-1000hpa
+hourly maximum Downward Vertical Velocity between 100-1000hpa
 1
 tmpl4_8
 MAXDVV
 NCEP
 MAX
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1
 10000.
-isobaric_sfc
+spec_pres_above_grnd
 0
 ?
 1


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR updates the UPP fix files to be consistent with the latest merged code.  Note, EMC now has a "makefile" under UPP/parm/ which generates all the postxconfig-NT.txt files for the many modeling systems, and all systems used a merged "post_avblflds.xml" file.  So this PR introduces the unified post_avblflds.xml to fix/upp/ directory under regional_workflow

## TESTS CONDUCTED: 
The new UPP static file was tested in retrospective mode for RRFS_NA_3km on Jet, and there were no changes to the GRIB2 output fields.

## DEPENDENCIES:
There is an associated PR for ufs-srweather-app: 
https://github.com/NOAA-GSL/ufs-srweather-app/pull/110