### PR TITLE
Adding FFG / ARI comparison for new RRFS_3km_CONUS_C3359 domain

### DIFF
--- a/fix/upp/RRFS_CONUS_3km/ari100y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari100y_01h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari100y_01h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari100y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari100y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari100y_03h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari100y_03h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari100y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari100y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari100y_06h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari100y_06h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari100y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari100y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari100y_12h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari100y_12h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari100y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari100y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari100y_24h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari100y_24h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari100y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari10y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari10y_01h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari10y_01h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari10y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari10y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari10y_03h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari10y_03h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari10y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari10y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari10y_06h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari10y_06h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari10y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari10y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari10y_12h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari10y_12h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari10y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari10y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari10y_24h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari10y_24h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari10y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari2y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari2y_01h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari2y_01h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari2y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari2y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari2y_03h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari2y_03h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari2y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari2y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari2y_06h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari2y_06h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari2y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari2y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari2y_12h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari2y_12h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari2y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari2y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari2y_24h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari2y_24h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari2y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari5y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari5y_01h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari5y_01h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari5y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari5y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari5y_03h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari5y_03h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari5y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari5y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari5y_06h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari5y_06h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari5y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari5y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari5y_12h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari5y_12h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari5y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km/ari5y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km/ari5y_24h.grib2
@@ -1,1 +1,1 @@
-../../.agent/upp/RRFS_CONUS_3km/ari5y_24h.grib2
+../../.agent/upp/RRFS_CONUS_3km_C3359/ari5y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_01h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari100y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_03h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari100y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_06h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari100y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_12h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari100y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari100y_24h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari100y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_01h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari10y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_03h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari10y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_06h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari10y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_12h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari10y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari10y_24h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari10y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_01h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari2y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_03h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari2y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_06h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari2y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_12h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari2y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari2y_24h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari2y_24h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_01h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_01h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari5y_01h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_03h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_03h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari5y_03h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_06h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_06h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari5y_06h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_12h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_12h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari5y_12h.grib2

--- a/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_24h.grib2
+++ b/fix/upp/RRFS_CONUS_3km_HRRRIC/ari5y_24h.grib2
@@ -1,0 +1,1 @@
+../../.agent/upp/RRFS_CONUS_3km_HRRRIC/ari5y_24h.grib2

--- a/scripts/exregional_run_post.sh
+++ b/scripts/exregional_run_post.sh
@@ -311,14 +311,16 @@ fi
 cp_vrfy ${post_config_fp} ./postxconfig-NT.txt
 cp_vrfy ${post_params_fp} ./params_grib2_tbl_new
 cp_vrfy ${EXECDIR}/upp.x .
-if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ]; then
+if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km_HRRRIC" ]; then
   grid_specs_rrfs="lambert:-97.5:38.500000 237.826355:1746:3000 21.885885:1014:3000"
+elif [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ]; then
+  grid_specs_rrfs="lambert:-97.5:38.500000 237.280700:1799:3000 21.138120:1057:3000"
 elif [ ${PREDEF_GRID_NAME} = "RRFS_NA_3km" ]; then
   grid_specs_rrfs="rot-ll:248.000000:-42.000000:0.000000 309.000000:4081:0.025000 -33.0000000:2641:0.025000"
 elif [ ${PREDEF_GRID_NAME} = "GSD_RAP13km" ]; then
   grid_specs_rrfs="rot-ll:254.000000:-36.000000:0.000000 304.174600:956:0.1169118 -48.5768500:831:0.1170527"
 fi
-if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ] || [ ${PREDEF_GRID_NAME} = "RRFS_NA_3km" ] || [ ${PREDEF_GRID_NAME} = "GSD_RAP13km" ]; then
+if [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km_HRRRIC" ] || [ ${PREDEF_GRID_NAME} = "RRFS_CONUS_3km" ] || [ ${PREDEF_GRID_NAME} = "RRFS_NA_3km" ] || [ ${PREDEF_GRID_NAME} = "GSD_RAP13km" ]; then
   if [ -f ${FFG_DIR}/latest.FFG ]; then
     cp_vrfy ${FFG_DIR}/latest.FFG .
     wgrib2 latest.FFG -match "0-12 hour" -end -new_grid_interpolation bilinear -new_grid_winds grid -new_grid ${grid_specs_rrfs} ffg_12h.grib2


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
Adding interpolation of ARI and FFG grids to new RRFS_3km_CONUS_C3359 grid.  This involved new soft links for the interpolated ARI static files for this domain, and modifications for interpolating FFG to this grid.

## TESTS CONDUCTED: 
Tests were conducted for RRFS_3km_CONUS_C3359 on Jet using realtime netCDF files.  