### PR TITLE
Introduce new fields from bgrd3d files to be copied into bgsfc files.

### DIFF
--- a/fix/upp/testbed_fields_bgrd3d.txt
+++ b/fix/upp/testbed_fields_bgrd3d.txt
@@ -1,0 +1,9 @@
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=77:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=78:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=79:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=80:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=81:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=82:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=83:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=84:top of atmosphere:
+:var discipline=3 center=7 local_table=1 parmcat=192 parm=85:top of atmosphere:

--- a/scripts/exregional_run_wgrib2.sh
+++ b/scripts/exregional_run_wgrib2.sh
@@ -227,6 +227,13 @@ if [[ ! -z ${TESTBED_FIELDS_FN} ]]; then
     echo "${FIX_UPP}/${TESTBED_FIELDS_FN} not found"
   fi
 fi
+if [[ ! -z ${TESTBED_FIELDS_FN2} ]]; then
+  if [[ -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} ]]; then
+    wgrib2 ${bgrd3d} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} | wgrib2 -i -grib ${bgsfc} ${bgrd3d}
+  else
+    echo "${FIX_UPP}/${TESTBED_FIELDS_FN2} not found"
+  fi
+fi
 
 #Link output for transfer to Jet
 # Should the following be done only if on jet??

--- a/scripts/exregional_run_wgrib2.sh
+++ b/scripts/exregional_run_wgrib2.sh
@@ -229,7 +229,7 @@ if [[ ! -z ${TESTBED_FIELDS_FN} ]]; then
 fi
 if [[ ! -z ${TESTBED_FIELDS_FN2} ]]; then
   if [[ -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} ]]; then
-    wgrib2 ${bgrd3d} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} | wgrib2 -i -grib ${bgsfc} ${bgrd3d}
+    wgrib2 ${bgrd3d} | grep -F -f ${FIX_UPP}/${TESTBED_FIELDS_FN2} | wgrib2 -i -append -grib ${bgsfc} ${bgrd3d}
   else
     echo "${FIX_UPP}/${TESTBED_FIELDS_FN2} not found"
   fi

--- a/ush/config.sh.RRFS_CONUS_13km
+++ b/ush/config.sh.RRFS_CONUS_13km
@@ -113,6 +113,7 @@ TAG="RRFS_CONUS_13km"
 
 USE_CUSTOM_POST_CONFIG_FILE="TRUE"
 TESTBED_FIELDS_FN="testbed_fields_bgdawp.txt"
+TESTBED_FIELDS_FN2="testbed_fields_bgrd3d.txt"
 CUSTOM_POST_CONFIG_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/postxconfig-NT-fv3lam_rrfs.txt"
 CUSTOM_POST_PARAMS_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/params_grib2_tbl_new"
 ARCHIVEDIR="/1year/BMC/wrfruc/rrfs_dev1

--- a/ush/config.sh.RRFS_CONUS_3km
+++ b/ush/config.sh.RRFS_CONUS_3km
@@ -152,6 +152,7 @@ TAG="RRFS_CONUS_3km"
 
 USE_CUSTOM_POST_CONFIG_FILE="TRUE"
 TESTBED_FIELDS_FN="testbed_fields_bgdawp.txt"
+TESTBED_FIELDS_FN2="testbed_fields_bgrd3d.txt"
 CUSTOM_POST_CONFIG_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/postxconfig-NT-fv3lam_rrfs.txt"
 CUSTOM_POST_PARAMS_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/params_grib2_tbl_new"
 ARCHIVEDIR="/1year/BMC/wrfruc/rrfs_dev1"

--- a/ush/config.sh.RRFS_NA_13km
+++ b/ush/config.sh.RRFS_NA_13km
@@ -124,6 +124,7 @@ TAG="RRFS_dev1_NA_13km"
 
 USE_CUSTOM_POST_CONFIG_FILE="TRUE"
 TESTBED_FIELDS_FN="testbed_fields_bgdawp.txt"
+TESTBED_FIELDS_FN2="testbed_fields_bgrd3d.txt"
 CUSTOM_POST_CONFIG_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/postxconfig-NT-fv3lam_rrfs.txt"
 CUSTOM_POST_PARAMS_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/params_grib2_tbl_new"
 ARCHIVEDIR="/5year/BMC/wrfruc/rrfs_na_13km_dev1"

--- a/ush/config.sh.RRFS_NA_3km
+++ b/ush/config.sh.RRFS_NA_3km
@@ -153,6 +153,7 @@ TAG="RRFS_dev1_NA_3km"
 
 USE_CUSTOM_POST_CONFIG_FILE="TRUE"
 TESTBED_FIELDS_FN="testbed_fields_bgdawp.txt"
+TESTBED_FIELDS_FN2="testbed_fields_bgrd3d.txt"
 # Below:  use EMC_post control file from 13-km NA configuration (provisional only)
 CUSTOM_POST_CONFIG_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/postxconfig-NT-fv3lam_rrfs.txt"
 CUSTOM_POST_PARAMS_FP="$(cd "$( dirname "${BASH_SOURCE[0]}" )/.." &>/dev/null&&pwd)/fix/upp/params_grib2_tbl_new"

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -1769,6 +1769,7 @@ CUSTOM_POST_PARAMS_FP=""
 POST_FULL_MODEL_NAME="FV3R"
 POST_SUB_MODEL_NAME="NONE"
 TESTBED_FIELDS_FN=""
+TESTBED_FIELDS_FN2=""
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR enables copying of fields from the bgrd3d GRIB2 files into the small testbed bgsfc files.  This is required because some new fields (simulated satellite brightness temperatures) are produced in the bgrd3d files, and collaborators need access via LDM, so the files need to be small.

The PR involves introducing a new "testbed_fields_bgrd3d.txt" list of fields under fix/upp/.  These fields are copied from bgrd3d to bgsfc files in exregional_run_wgrib2.sh script.

## TESTS CONDUCTED: 
This capability was tested in retrospective mode for RRFS_NA_3km on Jet.  

## DEPENDENCIES:
None

## DOCUMENTATION:
None

