### PR TITLE
Adding legacy and experimental ceiling and visibility into bgsfc

### DIFF
--- a/fix/upp/testbed_fields_bgdawp.txt
+++ b/fix/upp/testbed_fields_bgdawp.txt
@@ -21,6 +21,9 @@ UGRD:10 m above ground:
 VGRD:10 m above ground:
 WIND:10 m above ground:
 APCP:surface:
+CEIL:cloud base:
+HGT:cloud ceiling:
+VIS:surface:
 CAPE:surface:
 CIN:surface:
 CAPE:180-0 mb above ground:


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
MDL noted that the RRFS_NA_3km bgsfc files no longer contain any ceiling and visibility forecasts.  This PR reinstates those fields into the bgsfc files.

## TESTS CONDUCTED: 
Change was made on disk for the RRFS_NA_3km system on Jet, and fields are showing up in bgsfc files as expected.

## DEPENDENCIES:
None

## DOCUMENTATION:
None