### PR TITLE
Adding lightning threat indices to testbed files.

### DIFF
--- a/fix/upp/testbed_fields_bgrd3d.txt
+++ b/fix/upp/testbed_fields_bgrd3d.txt
@@ -17,3 +17,6 @@
 :var discipline=3 center=7 local_table=1 parmcat=192 parm=83:top of atmosphere:
 :var discipline=3 center=7 local_table=1 parmcat=192 parm=84:top of atmosphere:
 :var discipline=3 center=7 local_table=1 parmcat=192 parm=85:top of atmosphere:
+:var discipline=0 master_table=2 parmcat=17 parm=0:1 m above ground:
+:var discipline=0 master_table=2 parmcat=17 parm=0:2 m above ground:
+:LTNG:entire atmosphere:


### PR DESCRIPTION
# --- Delete this line and those above before hitting "Create pull request" ---

## DESCRIPTION OF CHANGES: 
Collaborators at Wisconsin need to see the lightning threat indices in RRFS.  This PR adds those fields in the testbed files.

## TESTS CONDUCTED: 
None

## DEPENDENCIES:
Needs this UPP PR to be merged first: https://github.com/NOAA-EMC/UPP/pull/695

## DOCUMENTATION:
None
