### PR TITLE
fix anavinfo.rrfs_conv_dbz to assimilate radar reflectivity in hybrid-EnVar

### DIFF
--- a/fix/gsi/anavinfo.rrfs_conv_dbz
+++ b/fix/gsi/anavinfo.rrfs_conv_dbz
@@ -69,13 +69,13 @@ control_vector::
  t        65      0       1.40        -1.0     state    tv
  q        65      1       0.80        -1.0     state    q
  sst       1      0       1.00        -1.0     state    sst
+ w        65     11       0.00        -1.0     state    w
+ qr       65     11       0.00        -1.0     state    qr
+ qs       65     11       0.00        -1.0     state    qs
+ qi       65     11       0.00        -1.0     state    qi
+ qg       65     11       0.00        -1.0     state    qg
+ ql       65     11       0.00        -1.0     state    qc
+ dbz      65     11       0.00        -1.0     state    dbz
  stl       1      0       1.00        -1.0     motley   sst
  sti       1      0       1.00        -1.0     motley   sst
- w        65     11       1.00        -1.0     state    w
- qr       65     11       1.00        -1.0     state    qr
- qs       65     11       1.00        -1.0     state    qs
- qi       65     11       1.00        -1.0     state    qi
- qg       65     11       1.00        -1.0     state    qg
- ql       65     11       1.00        -1.0     state    qc
- dbz      65     11       1.00        -1.0     state    dbz
 ::


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR fixes the improper setting of control vectors in anavinfo.rrfs_conv_dbz. According to the GSI code, "motley" variables should be set at the end in this file. In addition, "as/tsfc_sdv" should be zero for control variables added for dbz DA (w,qr,qs,qi,qg,ql,dbz) not to set default static B of these variables in current RRFS.

## TESTS CONDUCTED: 
I checked that EnVar using current anavinfo.rrfs_conv_dbz failed in the case of 200 MPI processes and that the fixed one could obtain the reasonable analysis.

## DEPENDENCIES:
- https://github.com/NOAA-GSL/regional_workflow/pull/451
- https://github.com/NOAA-GSL/regional_workflow/pull/533

## DOCUMENTATION:
TBD

## ISSUE (optional): 
This bug is introduced in https://github.com/NOAA-GSL/regional_workflow/pull/451 and became obvious after https://github.com/NOAA-GSL/regional_workflow/pull/533
