### PR TITLE
bugfix on exregional_run_prdgen.sh

### DIFF
--- a/scripts/exregional_run_prdgen.sh
+++ b/scripts/exregional_run_prdgen.sh
@@ -340,6 +340,10 @@ fi
 else
   echo "this grid is not ready for parallel prdgen: ${PREDEF_GRID_NAME}"
 fi
+
+rm -fr $DATAprdgen
+rm -f $DATA/*.t${cyc}z.*.f${fhr}.*.grib2
+
 else
 #
 # use single core to process all addition grids.
@@ -405,8 +409,6 @@ fi
 fi  # block for parallel or series wgrib2 runs.
 
 rm_vrfy -rf ${fhr_dir}
-rm -fr $DATAprdgen
-rm -f $DATA/*.t${cyc}z.*.f${fhr}.*.grib2
 #
 #-----------------------------------------------------------------------
 #


### PR DESCRIPTION
If DO_PARALLEL_PRDGEN == "FALSE", the script will abort:
`DATAprdgen: unbound variable
`

coauthor: @AnnetteGibbs-NOAA 