### PR TITLE
Adding ice number concentration for RRFS output.

### DIFF
--- a/ush/templates/diag_table.FV3_HRRR
+++ b/ush/templates/diag_table.FV3_HRRR
@@ -118,7 +118,7 @@
 "gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
 "gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
-#"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "rain_nc",     "rain_nc",    "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "water_nc",    "water_nc",   "fv3_history",  "all",  .false.,  "none",  2
 

--- a/ush/templates/diag_table.FV3_HRRR_gf
+++ b/ush/templates/diag_table.FV3_HRRR_gf
@@ -118,7 +118,7 @@
 "gfs_dyn",     "ps",          "pressfc",   "fv3_history",    "all",  .false.,  "none",  2
 "gfs_dyn",     "hs",          "hgtsfc",    "fv3_history",    "all",  .false.,  "none",  2
 "gfs_phys",    "refl_10cm"    "refl_10cm"  "fv3_history",    "all",  .false.,  "none",  2
-#"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
+"gfs_dyn",     "ice_nc",      "nicp",      "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "rain_nc",     "rain_nc",    "fv3_history",  "all",  .false.,  "none",  2
 "gfs_dyn",     "water_nc",    "water_nc",   "fv3_history",  "all",  .false.,  "none",  2
 


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
We need to enable output of ice number concentration for RRFS, to match legacy products.  This PR enables output of ice number concentration, nicp, in the dynf* files for RRFS.

## TESTS CONDUCTED: 
The change was made in realtime for RRFS-B on Jet.  

## DEPENDENCIES:
None

## DOCUMENTATION:
None

