### PR TITLE
Add hydrometeor uncertainty

### DIFF
--- a/scripts/exregional_nonvarcldanl.sh
+++ b/scripts/exregional_nonvarcldanl.sh
@@ -165,6 +165,9 @@ else
     bkpath=${cycle_dir}${slash_ensmem_subdir}/fcst_fv3lam${cycle_tag}/INPUT
 fi
 
+# Copy analysis fields into uncertainties
+cp_vrfy ${bkpath}/fv_tracer.res.tile1.nc  ${bkpath}/fv_tracer.unc.tile1.nc
+
 n_iolayouty=$(($IO_LAYOUT_Y-1))
 list_iolayout=$(seq 0 $n_iolayouty)
 
@@ -175,6 +178,7 @@ if [ -r "${bkpath}/coupler.res" ]; then # Use background from warm restart
   if [ "${IO_LAYOUT_Y}" == "1" ]; then
     ln_vrfy -s ${bkpath}/fv_core.res.tile1.nc         fv3_dynvars
     ln_vrfy -s ${bkpath}/fv_tracer.res.tile1.nc       fv3_tracer
+    ln_vrfy -s ${bkpath}/fv_tracer.unc.tile1.nc       fv3_tracer_unc
     ln_vrfy -s ${bkpath}/sfc_data.nc                  fv3_sfcdata
     ln_vrfy -s ${bkpath}/phy_data.nc                  fv3_phydata
   else
@@ -183,6 +187,7 @@ if [ -r "${bkpath}/coupler.res" ]; then # Use background from warm restart
       iii=$(printf %4.4i $ii)
       ln_vrfy -s ${bkpath}/fv_core.res.tile1.nc.${iii}         fv3_dynvars.${iii}
       ln_vrfy -s ${bkpath}/fv_tracer.res.tile1.nc.${iii}       fv3_tracer.${iii}
+      ln_vrfy -s ${bkpath}/fv_tracer.unc.tile1.nc.${iii}       fv3_tracer_unc.${iii}
       ln_vrfy -s ${bkpath}/sfc_data.nc.${iii}                  fv3_sfcdata.${iii}
       ln_vrfy -s ${bkpath}/phy_data.nc.${iii}                  fv3_phydata.${iii}
       ln_vrfy -s ${gridspec_dir}/fv3_grid_spec.${iii}          fv3_grid_spec.${iii}
@@ -312,6 +317,7 @@ cat << EOF > gsiparm.anl
    i_T_Q_adjust=${i_T_Q_adjust},
    l_rtma3d=${l_rtma3d},
    i_precip_vertical_check=${i_precip_vertical_check},
+   i_uncertainty=${i_uncertainty},
  /
 EOF
 

--- a/scripts/exregional_nonvarcldanl.sh
+++ b/scripts/exregional_nonvarcldanl.sh
@@ -165,8 +165,11 @@ else
     bkpath=${cycle_dir}${slash_ensmem_subdir}/fcst_fv3lam${cycle_tag}/INPUT
 fi
 
-# Copy analysis fields into uncertainties
-cp_vrfy ${bkpath}/fv_tracer.res.tile1.nc  ${bkpath}/fv_tracer.unc.tile1.nc
+if [ ${i_uncertainty} == ".true." ]; then
+  # Copy analysis fields into uncertainties - data will be overwritten
+  echo "EXREGIONAL_NONVARCLDANL.SH: copy tracer file into uncertainty file "
+  cp_vrfy ${bkpath}/fv_tracer.res.tile1.nc  ${bkpath}/fv_tracer.unc.tile1.nc
+fi
 
 n_iolayouty=$(($IO_LAYOUT_Y-1))
 list_iolayout=$(seq 0 $n_iolayouty)

--- a/scripts/exregional_nonvarcldanl.sh
+++ b/scripts/exregional_nonvarcldanl.sh
@@ -165,7 +165,7 @@ else
     bkpath=${cycle_dir}${slash_ensmem_subdir}/fcst_fv3lam${cycle_tag}/INPUT
 fi
 
-if [ ${l_uncertainty} == ".true." ]; then
+if [ ${l_cld_uncertainty} == ".true." ]; then
   # Copy analysis fields into uncertainties - data will be overwritten
   echo "EXREGIONAL_NONVARCLDANL.SH: copy tracer file into uncertainty file "
   cp_vrfy ${bkpath}/fv_tracer.res.tile1.nc  ${bkpath}/fv_tracer.unc.tile1.nc
@@ -320,7 +320,7 @@ cat << EOF > gsiparm.anl
    i_T_Q_adjust=${i_T_Q_adjust},
    l_rtma3d=${l_rtma3d},
    i_precip_vertical_check=${i_precip_vertical_check},
-   l_uncertainty=${l_uncertainty},
+   l_cld_uncertainty=${l_cld_uncertainty},
  /
 EOF
 

--- a/scripts/exregional_nonvarcldanl.sh
+++ b/scripts/exregional_nonvarcldanl.sh
@@ -165,7 +165,7 @@ else
     bkpath=${cycle_dir}${slash_ensmem_subdir}/fcst_fv3lam${cycle_tag}/INPUT
 fi
 
-if [ ${i_uncertainty} == ".true." ]; then
+if [ ${l_uncertainty} == ".true." ]; then
   # Copy analysis fields into uncertainties - data will be overwritten
   echo "EXREGIONAL_NONVARCLDANL.SH: copy tracer file into uncertainty file "
   cp_vrfy ${bkpath}/fv_tracer.res.tile1.nc  ${bkpath}/fv_tracer.unc.tile1.nc
@@ -320,7 +320,7 @@ cat << EOF > gsiparm.anl
    i_T_Q_adjust=${i_T_Q_adjust},
    l_rtma3d=${l_rtma3d},
    i_precip_vertical_check=${i_precip_vertical_check},
-   i_uncertainty=${i_uncertainty},
+   l_uncertainty=${l_uncertainty},
  /
 EOF
 

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -715,7 +715,7 @@ i_use_2mT4B=0
 i_T_Q_adjust=1
 l_rtma3d=.false.
 i_precip_vertical_check=0
-i_uncertainty=0
+i_uncertainty=.false.
 #  &CHEM 
 laeroana_fv3smoke=.false.
 berror_fv3_cmaq_regional=.false.

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -715,7 +715,7 @@ i_use_2mT4B=0
 i_T_Q_adjust=1
 l_rtma3d=.false.
 i_precip_vertical_check=0
-l_uncertainty=.false.
+l_cld_uncertainty=.false.
 #  &CHEM 
 laeroana_fv3smoke=.false.
 berror_fv3_cmaq_regional=.false.

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -715,6 +715,7 @@ i_use_2mT4B=0
 i_T_Q_adjust=1
 l_rtma3d=.false.
 i_precip_vertical_check=0
+i_uncertainty=0
 #  &CHEM 
 laeroana_fv3smoke=.false.
 berror_fv3_cmaq_regional=.false.

--- a/ush/config_defaults.sh
+++ b/ush/config_defaults.sh
@@ -715,7 +715,7 @@ i_use_2mT4B=0
 i_T_Q_adjust=1
 l_rtma3d=.false.
 i_precip_vertical_check=0
-i_uncertainty=.false.
+l_uncertainty=.false.
 #  &CHEM 
 laeroana_fv3smoke=.false.
 berror_fv3_cmaq_regional=.false.


### PR DESCRIPTION
### NOTE:  This PR was superseded by an updated version, #580   Closing this branch/PR.

### DESCRIPTION OF CHANGES:
There is a effort between EMC and GSL to include more information about uncertainty for RTMA aviation-related fields.  This is an initial set to include hydrometeor uncertainty in the RTMA output.

Specifically, the following changes were made:

- Add a logical flag (i_uncertainty) to the config_defaults script to turn on/off the creation of the uncertainties file.
Default is .false. (off), so if the flag is not included it or set to off, the uncertainty file creation is not performed.
- Create a template in the exregional_nonvarcldanl script for the uncertainty netcdf file by copying the fcst_fv3lam/INPUT/tracer file into the same directory.

Note that this is part I of a two-part update.  The changes to overwrite the fields in the template netcdf file are in the rrfs_utils/cloudanalysis fortran code, which will be included in a separate PR (rrfs_utl #41).  This PR should be merge before or with the rrfs_utl #41 PR.

**Type of change**

- [ ]  Bug fix (non-breaking change which fixes an issue)
- [x]  New feature (non-breaking change which adds functionality)
- [ ]  Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ]  This change requires a documentation update

### TESTS CONDUCTED:
- [ ]  hera.intel
- [ ]  orion.intel
- [ ]  cheyenne.intel
- [ ]  cheyenne.gnu
- [ ]  gaea.intel
- [x]  jet.intel
- [ ]  wcoss2.intel
- [ ]  NOAA Cloud (indicate which platform)
- [ ]  Jenkins
- [ ]  fundamental test suite
- [ ]  comprehensive tests (specify which if a subset was used)

### DEPENDENCIES:
This is part I of a two-part update. The changes to overwrite the fields in the template netcdf file are in the rrfs_utils/cloudanalysis fortran code, which will be included in a separate PR (rrfs_utl #41). This PR should be merge before or with the rrfs_utl #41 PR.

### DOCUMENTATION:
None

### ISSUE:
None.

### CHECKLIST
- [ ] My code follows the style guidelines in the Contributor's Guide
- [x]  I have performed a self-review of my own code using the Code Reviewer's Guide
- [x]  I have commented my code, particularly in hard-to-understand areas
- [ ]  My changes need updates to the documentation. I have made corresponding changes to the documentation
- [ ]  My changes do not require updates to the documentation (explain).
- [ ]  My changes generate no new warnings
- [ ]  New and existing tests pass with my changes
- [ ]  Any dependent changes have been merged and published