### PR TITLE
Fix anavinfo not to use vertical velocity for CRTM

### DIFF
--- a/fix/gsi/anavinfo.enkf.rrfs_dbz
+++ b/fix/gsi/anavinfo.enkf.rrfs_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical_velocity    w
+  w        65      -1         vertical_velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone

--- a/fix/gsi/anavinfo.rrfs_conv_dbz
+++ b/fix/gsi/anavinfo.rrfs_conv_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical velocity    w
+  w        65      -1         vertical velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone

--- a/fix/gsi/anavinfo.rrfs_dbz
+++ b/fix/gsi/anavinfo.rrfs_dbz
@@ -4,7 +4,7 @@ met_guess::
   z         1      -1         geopotential_height  phis
   u        65       2         zonal_wind           u
   v        65       2         meridional_wind      v
-  w        65       2         vertical velocity    w
+  w        65      -1         vertical velocity    w
   tv       65       2         virtual_temperature  tv
   q        65       2         specific_humidity    sphu
   oz       65       2         ozone                ozone


### PR DESCRIPTION
## DESCRIPTION OF CHANGES: 
This PR is to prevent SDL/VDL failure (NaN is sometimes detected in the 2nd outer loop) in GSI. This failure is caused by adding w (vertical velocity) to one of the variables for calculating radiance, so crtm_use for w in anavinfo is changed from 2 to -1.

## TESTS CONDUCTED: 
I checked this fix doesn't change the analysis and prevents NaN in several reruns as we expected.

## DEPENDENCIES:

## DOCUMENTATION:

## ISSUE (optional): 
This bug is introduced in https://github.com/NOAA-GSL/regional_workflow/pull/451
